### PR TITLE
feat: support shell virtual folders in CoreExtensions custom folders

### DIFF
--- a/Plugins/CoreExtensions/CoreExtensions.csproj
+++ b/Plugins/CoreExtensions/CoreExtensions.csproj
@@ -6,7 +6,7 @@
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Lertaro.Plugins.CoreExtensions</AssemblyName>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
       <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
 

--- a/Plugins/CoreExtensions/Providers/Indexing/StartMenuAppFolderRoots.cs
+++ b/Plugins/CoreExtensions/Providers/Indexing/StartMenuAppFolderRoots.cs
@@ -1,3 +1,5 @@
+using Lertaro.PluginSdk.Helpers;
+
 namespace Lertaro.Plugins.CoreExtensions.Providers.Indexing;
 
 /// <summary>
@@ -10,9 +12,11 @@ internal static class StartMenuAppFolderRoots
     internal static IReadOnlyList<string> Merge(
         IEnumerable<string> builtInRoots,
         IEnumerable<string>? customRoots,
-        Func<string, bool> directoryExists)
+        Func<string, bool> directoryExists,
+        Func<string, string>? resolveVirtualPath = null)
     {
         var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolve = resolveVirtualPath ?? ShellPathHelper.TryResolveVirtualPath;
         Add(builtInRoots);
         if (customRoots != null)
             Add(customRoots);
@@ -26,6 +30,7 @@ internal static class StartMenuAppFolderRoots
                     continue;
 
                 var path = Environment.ExpandEnvironmentVariables(candidate.Trim());
+                path = resolve(path);
                 if (!directoryExists(path))
                     continue;
 

--- a/Tests/Plugins/CoreExtensions/Providers/Indexing/StartMenuAppFolderRootsTests.cs
+++ b/Tests/Plugins/CoreExtensions/Providers/Indexing/StartMenuAppFolderRootsTests.cs
@@ -17,6 +17,22 @@ public sealed class StartMenuAppFolderRootsTests
     }
 
     [TestMethod]
+    public void Merge_ResolvesVirtualShellPathsBeforeCheckingExistence()
+    {
+        var resolvedStartup = @"C:\Users\testuser\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup";
+
+        var roots = StartMenuAppFolderRoots.Merge(
+            [],
+            ["shell:startup", @"C:\Real"],
+            path => path is @"C:\Users\testuser\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup" or @"C:\Real",
+            path => path.StartsWith("shell:", StringComparison.OrdinalIgnoreCase) ? resolvedStartup : path);
+
+        CollectionAssert.AreEquivalent(
+            new[] { resolvedStartup, @"C:\Real" },
+            roots.ToList());
+    }
+
+    [TestMethod]
     public void Merge_DeduplicatesRepeatedRootsAndDropsBlankOrMissingEntries()
     {
         var roots = StartMenuAppFolderRoots.Merge(


### PR DESCRIPTION
支持将 `shell:appsfolder` 等虚拟路径作为路径传入“核心功能扩展插件”的“自定义应用搜索文件夹”功能