### PR TITLE
feat: support negated glob filters in quick panel sources

### DIFF
--- a/App/Services/QuickPanel/QuickPanelFilterParser.cs
+++ b/App/Services/QuickPanel/QuickPanelFilterParser.cs
@@ -4,17 +4,19 @@ namespace Lertaro.App.Services.QuickPanel;
 
 /// <summary>
 /// Parsed QuickPanel source filter: the glob patterns the index enumerator already understands, plus
-/// the search-syntax "@" token filters that must be applied after enumeration. Glob and token entries
-/// are OR-ed together, matching the existing wildcard-only filter semantics.
+/// the search-syntax "@" token filters that must be applied after enumeration. Positive glob and token
+/// entries are OR-ed together, matching the existing wildcard-only filter semantics; entries prefixed
+/// with "!" (e.g. "!*.xxx") are exclusions removed after the positive set is computed.
 /// </summary>
 public sealed class QuickPanelFilterSpec
 {
-    public static QuickPanelFilterSpec MatchAll { get; } = new(new[] { "*" }, Array.Empty<string>());
+    public static QuickPanelFilterSpec MatchAll { get; } = new(new[] { "*" }, Array.Empty<string>(), Array.Empty<string>());
 
-    public QuickPanelFilterSpec(string[] globPatterns, string[] tokenFilters)
+    public QuickPanelFilterSpec(string[] globPatterns, string[] tokenFilters, string[] excludedGlobPatterns)
     {
         GlobPatterns = globPatterns;
         TokenFilters = tokenFilters;
+        ExcludedGlobPatterns = excludedGlobPatterns;
     }
 
     /// <summary>Filename patterns for the index enumerator / glob matching. Empty when only token filters exist.</summary>
@@ -23,13 +25,25 @@ public sealed class QuickPanelFilterSpec
     /// <summary>Search-syntax "@" tokens without the global ":" prefix, e.g. "@doc" or "@doc|img".</summary>
     public string[] TokenFilters { get; }
 
+    /// <summary>"!"-prefixed glob entries, e.g. "*.xxx" for "!*.xxx"; removed after positive matching.</summary>
+    public string[] ExcludedGlobPatterns { get; }
+
     public bool HasTokenFilters => TokenFilters.Length > 0;
+    public bool HasExcludedGlobPatterns => ExcludedGlobPatterns.Length > 0;
+
+    /// <summary>Whether parsing produced no filter at all (only the match-all "*" glob).</summary>
+    public bool IsMatchAll => GlobPatterns.Length == 1 && GlobPatterns[0] == "*"
+        && !HasTokenFilters && !HasExcludedGlobPatterns;
+
+    /// <summary>Whether the loader must run <c>ApplyFilterAsync</c> after enumeration.</summary>
+    public bool NeedsPostFilter => HasTokenFilters || HasExcludedGlobPatterns;
 }
 
 /// <summary>
-/// Splits a QuickPanel source filter into glob patterns and "@" token filters. Each entry must fully
-/// match one of the two syntaxes; a ":" entry that is not a valid "@" token is deliberately left as a
-/// glob pattern, where the colon can never match a real file name and the entry is effectively ignored.
+/// Splits a QuickPanel source filter into positive globs, "@" token filters, and "!"-negated globs.
+/// Each entry must fully match one of those syntaxes; a ":" entry that is not a valid "@" token is
+/// deliberately left as a glob pattern, where the colon can never match a real file name and the entry
+/// is effectively ignored. A bare "!" is invalid and ignored.
 /// </summary>
 public static class QuickPanelFilterParser
 {
@@ -38,9 +52,22 @@ public static class QuickPanelFilterParser
         var entries = FilterPatternHelper.Split(filterPattern ?? string.Empty);
         var globs = new List<string>();
         var tokens = new List<string>();
+        var excludedGlobs = new List<string>();
 
         foreach (var entry in entries)
         {
+            if (entry.StartsWith('!'))
+            {
+                var excluded = entry[1..];
+                if (excluded.Length == 0)
+                    continue; // invalid entry -- ignore
+
+                // First one wins when the same exclusion is listed twice.
+                if (!excludedGlobs.Contains(excluded, StringComparer.OrdinalIgnoreCase))
+                    excludedGlobs.Add(excluded);
+                continue;
+            }
+
             if (TryParseTokenFilter(entry, globalTokenPrefix, out var token))
             {
                 // Conflicting/duplicate token filters: first one wins.
@@ -54,12 +81,15 @@ public static class QuickPanelFilterParser
         }
 
         // Match-all is an enumeration signal for globs, not a pattern to match after the fact.
-        if (globs.Count == 0 && tokens.Count == 0)
+        if (globs.Count == 0 && tokens.Count == 0 && excludedGlobs.Count == 0)
             globs.Add("*");
-        else if (globs.Count > 1)
-            globs = globs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
 
-        return new QuickPanelFilterSpec(globs.ToArray(), tokens.ToArray());
+        if (globs.Count > 1)
+            globs = globs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (excludedGlobs.Count > 1)
+            excludedGlobs = excludedGlobs.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        return new QuickPanelFilterSpec(globs.ToArray(), tokens.ToArray(), excludedGlobs.ToArray());
     }
 
     internal static bool TryParseTokenFilter(string entry, char globalTokenPrefix, out string token)

--- a/App/Services/QuickPanel/QuickPanelSourceLoader.cs
+++ b/App/Services/QuickPanel/QuickPanelSourceLoader.cs
@@ -44,69 +44,85 @@ public static class QuickPanelSourceLoader
             var recent = await new SearchService()
                 .GetRecentFilesAsync(new[] { source.Path }, source.MaxItems, EffectiveMaxAge(source), token)
                 .ConfigureAwait(false);
-            if (filter.HasTokenFilters)
+            if (!filter.IsMatchAll)
             {
-                // ponytail: token filters run after the recency cap, so a filtered recent-files source
-                // can show fewer than MaxItems; fetching unbounded recency first would cost too much.
+                // ponytail: filters run after the recency cap, so a filtered recent-files source can
+                // show fewer than MaxItems; fetching unbounded recency first would cost too much.
                 recent = await ApplyFilterAsync(recent, filter).ConfigureAwait(false);
             }
             progress?.Report(recent);
             return recent;
         }
 
-        if (filter.HasTokenFilters)
+        var enumerationPattern = source.FilterPattern;
+        if (filter.NeedsPostFilter)
         {
-            // Enumerate without a file pattern: glob and token entries are OR-ed, so narrowing the
-            // enumeration to the glob subset would silently drop every token-only match.
-            var results = new List<SearchResult>();
-            var batch = new List<SearchResult>(64);
-            await IndexedDirectoryEnumerator.EnumerateAsync(source.Path, source.Recursive, string.Empty,
-                result => AddResult(result, source.Kind, results, batch, progress), limit: 0, token).ConfigureAwait(false);
-
-            if (batch.Count > 0)
-                progress?.Report(batch);
-
-            results = await ApplyFilterAsync(results, filter).ConfigureAwait(false);
-            return Order(results, source.Kind, source.SortByModified, source.MaxItems);
+            // With token filters OR-ed against globs, the enumeration must not be narrowed to the glob
+            // subset or every token-only match would be lost. Negated entries have to be applied after
+            // the positive set is known, so they also force a post-filter pass.
+            enumerationPattern = filter.HasTokenFilters
+                ? string.Empty
+                : filter.GlobPatterns.Length > 0 ? string.Join(';', filter.GlobPatterns) : string.Empty;
         }
 
-        var all = new List<SearchResult>();
-        var normalBatch = new List<SearchResult>(64);
-        await IndexedDirectoryEnumerator.EnumerateAsync(source.Path, source.Recursive, source.FilterPattern,
-            result => AddResult(result, source.Kind, all, normalBatch, progress), limit: 0, token).ConfigureAwait(false);
+        var results = new List<SearchResult>();
+        var batch = new List<SearchResult>(64);
+        await IndexedDirectoryEnumerator.EnumerateAsync(source.Path, source.Recursive, enumerationPattern,
+            result => AddResult(result, source.Kind, results, batch, progress), limit: 0, token).ConfigureAwait(false);
 
-        if (normalBatch.Count > 0)
-            progress?.Report(normalBatch);
+        if (batch.Count > 0)
+            progress?.Report(batch);
 
-        return Order(all, source.Kind, source.SortByModified, source.MaxItems);
+        if (filter.NeedsPostFilter)
+            results = await ApplyFilterAsync(results, filter).ConfigureAwait(false);
+
+        return Order(results, source.Kind, source.SortByModified, source.MaxItems);
     }
 
     private static async Task<List<SearchResult>> ApplyFilterAsync(List<SearchResult> results, QuickPanelFilterSpec filter)
     {
-        if (!filter.HasTokenFilters)
-            return results;
+        var hasMatchAllGlob = filter.GlobPatterns.Any(g => g is "*" or "*.*");
+        var hasNoPositiveFilter = filter.GlobPatterns.Length == 0 && filter.TokenFilters.Length == 0;
+        var includeAllPositive = hasMatchAllGlob || hasNoPositiveFilter;
 
         var matched = new HashSet<SearchResult>();
-        if (filter.GlobPatterns.Length > 0)
+        if (includeAllPositive)
         {
             foreach (var result in results)
+                matched.Add(result);
+        }
+        else
+        {
+            if (filter.GlobPatterns.Length > 0)
             {
-                if (FilterPatternHelper.Matches(result.Name, filter.GlobPatterns))
-                    matched.Add(result);
+                foreach (var result in results)
+                {
+                    if (FilterPatternHelper.Matches(result.Name, filter.GlobPatterns))
+                        matched.Add(result);
+                }
+            }
+
+            foreach (var token in filter.TokenFilters)
+            {
+                var provider = PluginManager.Instance.QueryTokenProviders.FirstOrDefault(p => p.CanHandle(token));
+                if (provider == null)
+                    continue; // entry did not fully match search syntax -- ignore it
+
+                var filtered = await provider.ApplyAsync(token, results);
+                foreach (var item in filtered)
+                {
+                    if (item is SearchResult sr)
+                        matched.Add(sr);
+                }
             }
         }
 
-        foreach (var token in filter.TokenFilters)
+        if (filter.ExcludedGlobPatterns.Length > 0)
         {
-            var provider = PluginManager.Instance.QueryTokenProviders.FirstOrDefault(p => p.CanHandle(token));
-            if (provider == null)
-                continue; // entry did not fully match search syntax -- ignore it
-
-            var filtered = await provider.ApplyAsync(token, results);
-            foreach (var item in filtered)
+            foreach (var result in results)
             {
-                if (item is SearchResult sr)
-                    matched.Add(sr);
+                if (matched.Contains(result) && FilterPatternHelper.Matches(result.Name, filter.ExcludedGlobPatterns))
+                    matched.Remove(result);
             }
         }
 

--- a/Plugins/CoreExtensions/Resources/Translations/en-US/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/en-US/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "Accept dropped files",
   "QuickPanel_AcceptsDropsTooltip": "Files and folders dragged onto this group are copied into its folder, using Windows' own file copy. Always a copy, never a move.",
   "QuickPanel_FilterPattern": "Filter",
-  "QuickPanel_FilterPatternTooltip": "One or more patterns separated by ';' or ',' (e.g. *.mp4;*.mkv). Leave blank for no filtering.",
+  "QuickPanel_FilterPatternTooltip": "Separate entries with ';' or ',' (e.g. `*.mp4;*.mkv`, `*.lnk;:@doc;:@img`). Prefix an entry with `!` to exclude it (`!*.xxx`). `:@doc` / `:@doc|img` are search-syntax category filters. Leave blank for no filtering.",
   "QuickPanel_MaxItems": "At most",
   "QuickPanel_MaxAge": "Changed within (minutes)",
   "QuickPanel_ProcessesDesc": "Apps this workspace belongs to, one process name per line (chrome or chrome.exe). Summon the panel over one of them and it opens on this workspace.",

--- a/Plugins/CoreExtensions/Resources/Translations/es-ES/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/es-ES/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "Aceptar archivos soltados",
   "QuickPanel_AcceptsDropsTooltip": "Los archivos y carpetas que sueltes en este grupo se copian en su carpeta con la copia de archivos de Windows. Siempre copia, nunca mueve.",
   "QuickPanel_FilterPattern": "Filtro",
-  "QuickPanel_FilterPatternTooltip": "Uno o varios patrones separados por ';' o ',' (p. ej. *.mp4;*.mkv). Déjelo vacío para no filtrar.",
+  "QuickPanel_FilterPatternTooltip": "Separa varias entradas con ';' o ',' (p. ej. `*.mp4;*.mkv`, `*.lnk;:@doc;:@img`). Antepón `!` para excluir una entrada (`!*.xxx`). `:@doc` / `:@doc|img` son filtros de categoría de la sintaxis de búsqueda. Déjalo vacío para no filtrar.",
   "QuickPanel_MaxItems": "Como máximo",
   "QuickPanel_MaxAge": "Modificados hace (minutos)",
   "QuickPanel_ProcessesDesc": "Aplicaciones a las que pertenece este espacio de trabajo, un nombre de proceso por línea (chrome o chrome.exe). Al abrir el panel sobre una de ellas, se abrirá en este espacio de trabajo.",

--- a/Plugins/CoreExtensions/Resources/Translations/ja-JP/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/ja-JP/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "ドロップされたファイルを受け取る",
   "QuickPanel_AcceptsDropsTooltip": "このグループにドラッグしたファイルやフォルダーは、Windows 自身のファイルコピーでこのフォルダーにコピーされます。常にコピーで、移動はしません。",
   "QuickPanel_FilterPattern": "フィルター",
-  "QuickPanel_FilterPatternTooltip": "「;」または「,」で複数のパターンを区切れます(例: *.mp4;*.mkv)。空欄はフィルターなしです。",
+  "QuickPanel_FilterPatternTooltip": "「;」または「,」で複数のフィルター項目を区切れます（例: `*.mp4;*.mkv`、`*.lnk;:@doc;:@img`）。項目の先頭に `!` を付けると除外します（例: `!*.xxx`）。`:@doc` / `:@doc|img` は検索構文のカテゴリフィルターです。空欄はフィルターなしです。",
   "QuickPanel_MaxItems": "最大",
   "QuickPanel_MaxAge": "変更が何分以内",
   "QuickPanel_ProcessesDesc": "このワークスペースに対応するアプリを 1 行に 1 つのプロセス名で指定します(chrome または chrome.exe)。該当するアプリ上でパネルを呼び出すと、このワークスペースが開きます。",

--- a/Plugins/CoreExtensions/Resources/Translations/ko-KR/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/ko-KR/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "끌어다 놓은 파일 받기",
   "QuickPanel_AcceptsDropsTooltip": "이 그룹에 끌어다 놓은 파일과 폴더는 Windows 자체 파일 복사로 이 폴더에 복사됩니다. 항상 복사이며 이동하지 않습니다.",
   "QuickPanel_FilterPattern": "필터",
-  "QuickPanel_FilterPatternTooltip": "';' 또는 ','로 여러 패턴을 구분할 수 있습니다(예: *.mp4;*.mkv). 비워 두면 필터링하지 않습니다.",
+  "QuickPanel_FilterPatternTooltip": "';' 또는 ','로 여러 필터 항목을 구분합니다(예: `*.mp4;*.mkv`, `*.lnk;:@doc;:@img`). 항목 앞에 `!`를 붙이면 제외합니다(예: `!*.xxx`). `:@doc` / `:@doc|img`는 검색 구문 카테고리 필터입니다. 비워 두면 필터링하지 않습니다.",
   "QuickPanel_MaxItems": "최대",
   "QuickPanel_MaxAge": "변경된 지 몇 분 이내",
   "QuickPanel_ProcessesDesc": "이 작업 공간에 해당하는 앱을 한 줄에 하나씩 프로세스 이름으로 적습니다(chrome 또는 chrome.exe). 해당 앱 위에서 패널을 열면 이 작업 공간으로 전환됩니다.",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-CN/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-CN/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "接收拖入的文件",
   "QuickPanel_AcceptsDropsTooltip": "拖到这个分组上的文件和文件夹会被复制进它的文件夹,使用 Windows 自己的文件复制。永远是复制,不会移动。",
   "QuickPanel_FilterPattern": "过滤",
-  "QuickPanel_FilterPatternTooltip": "可用「;」或「,」分隔多个模式(例如 *.mp4;*.mkv)。留空代表不过滤。",
+  "QuickPanel_FilterPatternTooltip": "可用「;」或「,」分隔多个过滤项（例如 `*.mp4;*.mkv`、`*.lnk;:@doc;:@img`）。在项前加 `!` 表示排除（例如 `!*.xxx`）。`:@doc` / `:@doc|img` 为搜索语法类别过滤器。留空代表不过滤。",
   "QuickPanel_MaxItems": "最多",
   "QuickPanel_MaxAge": "修改于多少分钟内",
   "QuickPanel_ProcessesDesc": "该工作区对应的应用,每行一个进程名(chrome 或 chrome.exe)。在这些应用上呼出面板时会自动切到该工作区。",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-HK/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-HK/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "接收拖入的檔案",
   "QuickPanel_AcceptsDropsTooltip": "拖到這個分組上的檔案和資料夾會被複製進它的資料夾,使用 Windows 自己的檔案複製。永遠是複製,不會移動。",
   "QuickPanel_FilterPattern": "篩選",
-  "QuickPanel_FilterPatternTooltip": "可以用「;」或者「,」分隔多個模式(例如 *.mp4;*.mkv)。留空代表不篩選。",
+  "QuickPanel_FilterPatternTooltip": "可以用「;」或者「,」分隔多個過濾項（例如 `*.mp4;*.mkv`、`*.lnk;:@doc;:@img`）。在項目前面加 `!` 表示排除（例如 `!*.xxx`）。`:@doc` / `:@doc|img` 係搜尋語法類別篩選器。留空代表不篩選。",
   "QuickPanel_MaxItems": "最多",
   "QuickPanel_MaxAge": "修改於幾多分鐘內",
   "QuickPanel_ProcessesDesc": "呢個工作區對應嘅應用程式,每行一個處理程序名(chrome 或者 chrome.exe)。喺呢啲應用程式上面呼出面板就會自動切去呢個工作區。",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-TW/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-TW/App.json
@@ -122,7 +122,7 @@
   "QuickPanel_AcceptsDrops": "接收拖入的檔案",
   "QuickPanel_AcceptsDropsTooltip": "拖到這個分組上的檔案和資料夾會被複製進它的資料夾,使用 Windows 自己的檔案複製。永遠是複製,不會移動。",
   "QuickPanel_FilterPattern": "篩選",
-  "QuickPanel_FilterPatternTooltip": "可用「;」或「,」分隔多個模式(例如 *.mp4;*.mkv)。留空代表不篩選。",
+  "QuickPanel_FilterPatternTooltip": "可用「;」或「,」分隔多個過濾項（例如 `*.mp4;*.mkv`、`*.lnk;:@doc;:@img`）。在項目前方加 `!` 表示排除（例如 `!*.xxx`）。`:@doc` / `:@doc|img` 為搜尋語法類別篩選器。留空代表不篩選。",
   "QuickPanel_MaxItems": "最多",
   "QuickPanel_MaxAge": "修改於多少分鐘內",
   "QuickPanel_ProcessesDesc": "此工作區對應的應用程式,每行一個處理程序名稱(chrome 或 chrome.exe)。在這些應用程式上呼出面板時會自動切換到此工作區。",

--- a/Tests/App/Services/QuickPanel/QuickPanelFilterParserTests.cs
+++ b/Tests/App/Services/QuickPanel/QuickPanelFilterParserTests.cs
@@ -86,4 +86,40 @@ public sealed class QuickPanelFilterParserTests
         CollectionAssert.AreEqual(new[] { "*.lnk" }, spec.GlobPatterns);
         CollectionAssert.AreEqual(new[] { "@doc" }, spec.TokenFilters);
     }
+    [TestMethod]
+    public void Parse_NegatedGlob_GoesToExcluded()
+    {
+        var spec = QuickPanelFilterParser.Parse("*.lnk;!*.desktop.ini");
+
+        CollectionAssert.AreEqual(new[] { "*.lnk" }, spec.GlobPatterns);
+        Assert.HasCount(0, spec.TokenFilters);
+        CollectionAssert.AreEqual(new[] { "*.desktop.ini" }, spec.ExcludedGlobPatterns);
+    }
+
+    [TestMethod]
+    public void Parse_ExclusionOnly_HasNoPositiveGlobs()
+    {
+        var spec = QuickPanelFilterParser.Parse("!desktop.ini");
+
+        Assert.HasCount(0, spec.GlobPatterns);
+        CollectionAssert.AreEqual(new[] { "desktop.ini" }, spec.ExcludedGlobPatterns);
+        Assert.IsFalse(spec.IsMatchAll);
+        Assert.IsTrue(spec.NeedsPostFilter);
+    }
+
+    [TestMethod]
+    public void Parse_BareNegation_IsIgnored()
+    {
+        var spec = QuickPanelFilterParser.Parse("!");
+
+        Assert.IsTrue(spec.IsMatchAll);
+    }
+
+    [TestMethod]
+    public void Parse_DuplicateNegatedGlobs_FirstWins()
+    {
+        var spec = QuickPanelFilterParser.Parse("!*.tmp;!*.tmp");
+
+        CollectionAssert.AreEqual(new[] { "*.tmp" }, spec.ExcludedGlobPatterns);
+    }
 }


### PR DESCRIPTION
因为快速面板的“最近的文件”勾选时，没有过滤系统文件（没有走设置-索引设置-排除那几个面板），所以写了个反向过滤
此外，补全了悬浮提示