### PR TITLE
修复诸多小问题

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -79,7 +79,7 @@ public partial class App : Application
         // The hash includes both SID and session, so accounts sharing a short username cannot collide
         // and no account/session identifier is exposed in the mutex name.
         var mutexName = $@"Local\Lertaro_App_{CurrentUserIdentity.SessionHash}";
-        _appMutex = new Mutex(true, mutexName, out var createdNew);
+        _appMutex = AppSingleInstance.AcquireMutex(mutexName, out var createdNew);
         if (!createdNew)
         {
             try

--- a/App/Services/AppSingleInstance.cs
+++ b/App/Services/AppSingleInstance.cs
@@ -1,0 +1,30 @@
+namespace Lertaro.App.Services;
+
+/// <summary>
+/// Owns the per-session named mutex that keeps the App single-instance.
+/// Split out of App.xaml.cs purely to keep that file under the repo's per-file line limit.
+/// </summary>
+public static class AppSingleInstance
+{
+    /// <summary>
+    /// Acquires the single-instance mutex, surviving an instance that crashed while holding it:
+    /// requesting initial ownership of an abandoned named mutex throws AbandonedMutexException, and
+    /// the dead owner means no live instance exists -- so ownership falls to this process, and it
+    /// runs as the single instance instead of aborting startup.
+    /// </summary>
+    public static Mutex AcquireMutex(string mutexName, out bool createdNew)
+    {
+        try
+        {
+            return new Mutex(true, mutexName, out createdNew);
+        }
+        catch (AbandonedMutexException)
+        {
+            // Re-open the same named mutex without requesting initial ownership: the abandoned
+            // acquisition already passed ownership to this process, and the handle keeps the mutex
+            // itself alive for this process's lifetime.
+            createdNew = true;
+            return new Mutex(false, mutexName);
+        }
+    }
+}

--- a/App/Services/Pipe/AppSearchPipeService.cs
+++ b/App/Services/Pipe/AppSearchPipeService.cs
@@ -236,12 +236,20 @@ public static class AppSearchPipeService
     private static async Task RunTokenizedSearchAsync(string query, IReadOnlyList<string> tokens, bool bypassExclusions, Stream pipe, CancellationToken token)
     {
         var raw = new List<SearchResult>();
+        // SearchStreamingAsync's onResult callback fires concurrently from its local/network tasks, and
+        // List<T>.Add is not safe under that -- same write-lock pattern RunStreamingSearchAsync uses.
+        var writeLock = new SemaphoreSlim(1, 1);
         await SharedSearchService.SearchStreamingAsync(
             query,
             SearchViewModel.FullSearchFileLimit,
             SearchViewModel.FullSearchAppLimit,
             null,
-            r => raw.Add(r),
+            r =>
+            {
+                writeLock.Wait();
+                try { raw.Add(r); }
+                finally { writeLock.Release(); }
+            },
             token,
             null,
             bypassExclusions);

--- a/App/Services/ShellMenu/QuickNav/DesktopIconHitTester.cs
+++ b/App/Services/ShellMenu/QuickNav/DesktopIconHitTester.cs
@@ -46,6 +46,14 @@ internal static class DesktopIconHitTester
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool CloseHandle(IntPtr hObject);
 
+    // Minimal rights this hit-test protocol actually needs: allocate/write/read remote memory and
+    // query the process -- not PROCESS_ALL_ACCESS, which is both unnecessary and can fail outright
+    // under stricter integrity-level boundaries.
+    private const uint PROCESS_VM_OPERATION = 0x0008;
+    private const uint PROCESS_VM_READ = 0x0010;
+    private const uint PROCESS_VM_WRITE = 0x0020;
+    private const uint PROCESS_QUERY_INFORMATION = 0x0400;
+
     public static bool IsPointOnDesktopIcon(IntPtr hwndListView, int x, int y)
     {
         var hProcess = IntPtr.Zero;
@@ -53,7 +61,9 @@ internal static class DesktopIconHitTester
         try
         {
             Native.GetWindowThreadProcessId(hwndListView, out var pid);
-            hProcess = OpenProcess(0x001F0FFF /* PROCESS_ALL_ACCESS */, false, pid);
+            hProcess = OpenProcess(
+                PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_INFORMATION,
+                false, pid);
             if (hProcess == IntPtr.Zero) return false;
 
             var pt = new PointNative.POINT { x = x, y = y };

--- a/App/ViewModels/LocalSend/LocalSendSendDeviceItem.cs
+++ b/App/ViewModels/LocalSend/LocalSendSendDeviceItem.cs
@@ -34,8 +34,9 @@ public sealed class LocalSendSendDeviceItem : INotifyPropertyChanged
                 if (lastDot > 0 && lastDot < ip.Length - 1)
                     return ip[(lastDot + 1)..];
             }
-            // Fallback to fingerprint hash if no IP available.
-            return (Math.Abs(Device.Fingerprint.GetHashCode()) % 10000).ToString("D4");
+            // Fallback to fingerprint hash if no IP available. Widen to long before Math.Abs:
+            // int.MinValue has no positive int counterpart, so Math.Abs throws OverflowException.
+            return (Math.Abs((long)Device.Fingerprint.GetHashCode()) % 10000).ToString("D4");
         }
     }
 

--- a/App/ViewModels/QuickPanel/QuickPanelViewModelWriteback.cs
+++ b/App/ViewModels/QuickPanel/QuickPanelViewModelWriteback.cs
@@ -60,11 +60,11 @@ public partial class QuickPanelViewModel
         // Dropped from what is already loaded rather than reloaded: closing a tab says nothing about what
         // the others hold, and the panel is open while this happens.
         _content.Remove(tabId);
-        _tabs = _tabs.Where(candidate => candidate.Id != tabId).ToList();
+        _tabs = _tabs.Where(candidate => !string.Equals(candidate.Id, tabId, StringComparison.OrdinalIgnoreCase)).ToList();
 
         // Closing the tab being looked at leaves the panel on the first one still there, rather than on
         // one that no longer has a tab to reach it by.
-        if (!_tabs.Any(candidate => candidate.Id == _activeTabId))
+        if (!_tabs.Any(candidate => string.Equals(candidate.Id, _activeTabId, StringComparison.OrdinalIgnoreCase)))
             _activeTabId = _tabs.Count > 0 ? _tabs[0].Id : string.Empty;
 
         RebuildTabs();

--- a/Cli/Program.cs
+++ b/Cli/Program.cs
@@ -66,12 +66,17 @@ try
 catch (Exception ex)
 {
     Console.Error.WriteLine($"[error] Could not reach the Lertaro App's search pipe within {AppSearchPipeClient.ConnectTimeoutMs}ms ({ex.GetType().Name}: {ex.Message}) -- is the Lertaro App running?");
+    Environment.ExitCode = 1;
     return;
 }
 
 var terminal = Lertaro.Cli.Terminal.Terminal.TryOpen();
 if (terminal == null)
-    return; // TryOpen already wrote the specific reason to stderr
+{
+    // TryOpen already wrote the specific reason to stderr
+    Environment.ExitCode = 1;
+    return;
+}
 
 var session = new SearchSession(pipeName);
 var renderer = new Renderer(terminal, session);

--- a/Core/IndexV2/Delta/DeltaOverlay.cs
+++ b/Core/IndexV2/Delta/DeltaOverlay.cs
@@ -86,8 +86,19 @@ public sealed class DeltaOverlay
 
         if (_addedById.TryGetValue(id, out var deltaIdx))
         {
-            var wasDirectory = IsDir(Added[deltaIdx].Flags);
-            if (wasDirectory != isDirectory) { CountRemoved(wasDirectory); CountAdded(isDirectory); }
+            var existing = Added[deltaIdx];
+            var wasDirectory = IsDir(existing.Flags);
+            if (existing.Removed)
+            {
+                // Resurrection: the earlier Remove already decounted this row, so bringing it back
+                // counts as a fresh add (the prior add/remove pair nets to zero either way).
+                CountAdded(isDirectory);
+            }
+            else if (wasDirectory != isDirectory)
+            {
+                CountRemoved(wasDirectory);
+                CountAdded(isDirectory);
+            }
             Added[deltaIdx] = record;
         }
         else if (TryFindBaseRow(id, out var baseRow) && !DeletedBase.Contains(baseRow) && !RenamedAway.ContainsKey(baseRow))
@@ -157,72 +168,11 @@ public sealed class DeltaOverlay
         return (Snapshot.Sizes[baseRow], Snapshot.CreationTimes[baseRow], Snapshot.LastWriteTimes[baseRow], Snapshot.LastAccessTimes[baseRow]);
     }
 
-    // Same Path.Combine chain as Snapshot.GetFullPath, with delta overrides patched in along the walk.
-    // Stepping onto a renamed-away row forwards to the FRN's live row (delta or base); with no live
-    // row yet, the accumulated tail hangs off the source root, like the old engine's re-orphaned rows.
-    public string GetFullPath(int baseRow)
-    {
-        var segments = new List<string>(8);
-        var current = baseRow;
-        for (var depth = 0; depth < 512; depth++)
-        {
-            if (RenamedAway.TryGetValue(current, out var awayFrn))
-            {
-                if (FindAddedDirectory(awayFrn) is { } liveRecord)
-                    return AppendSegments(GetFullPath(liveRecord), segments);
-                if (TryFindLiveBaseDirectory(awayFrn, out var liveRow) && liveRow != current)
-                {
-                    current = liveRow;
-                    continue;
-                }
-                return AppendSegments(Snapshot.SourceRoot, segments);
-            }
-
-            var parent = ParentOf(current);
-            segments.Add(NameOf(current));
-            if (parent < 0 || parent == current)
-                break;
-            current = parent;
-        }
-        return AppendSegments(Snapshot.SourceRoot, segments);
-    }
-
-    internal string GetFullPath(DeltaRecord record)
-    {
-        // The eagerly-resolved parent row only counts while it is still LIVE -- a tombstoned/renamed-
-        // away parent falls through to FRN re-resolution, and with no live heir the record hangs off
-        // the source root exactly like a re-orphaned old-engine row.
-        var parentPath = GetParentPath(record);
-        return parentPath[^1] == '\\' ? parentPath + record.Name : parentPath + "\\" + record.Name;
-    }
-
-    // The resolved directory path a DeltaRecord's parent link currently points at -- exposed
-    // separately from GetFullPath(record) so path-mode search can run its own directory-segment
-    // matching against it without reconstructing it via string surgery on the child's full path.
-    internal string GetParentPath(DeltaRecord record)
-    {
-        if (record.ParentBaseRow >= 0 && !DeletedBase.Contains(record.ParentBaseRow) && !RenamedAway.ContainsKey(record.ParentBaseRow))
-            return GetFullPath(record.ParentBaseRow);
-        if (TryFindLiveBaseDirectory(record.ParentFrn, out var baseRow))
-            return GetFullPath(baseRow);
-        if (FindAddedDirectory(record.ParentFrn) is { } parentRecord)
-            return GetFullPath(parentRecord);
-        return Snapshot.SourceRoot;
-    }
-
-    private static string AppendSegments(string basePath, List<string> reversedSegments)
-    {
-        var builder = new System.Text.StringBuilder(basePath, 64);
-        for (var i = reversedSegments.Count - 1; i >= 0; i--)
-        {
-            if (reversedSegments[i].Length == 0)
-                continue;
-            if (builder[^1] != '\\')
-                builder.Append('\\');
-            builder.Append(reversedSegments[i]);
-        }
-        return builder.ToString();
-    }
+    // Path building lives in DeltaPathBuilder (composition, purely to keep this file under the repo's
+    // per-file line limit); the builder has no state of its own and always operates on this overlay.
+    public string GetFullPath(int baseRow) => DeltaPathBuilder.GetFullPath(this, baseRow);
+    internal string GetFullPath(DeltaRecord record) => DeltaPathBuilder.GetFullPath(this, record);
+    internal string GetParentPath(DeltaRecord record) => DeltaPathBuilder.GetParentPath(this, record);
 
     internal DeltaRecord? FindAddedDirectory(UInt128 frn)
     {

--- a/Core/IndexV2/Delta/DeltaPathBuilder.cs
+++ b/Core/IndexV2/Delta/DeltaPathBuilder.cs
@@ -1,0 +1,74 @@
+namespace Lertaro.Core.IndexV2.Delta;
+
+// Split out of DeltaOverlay purely to keep that file under the repo's per-file line limit; this
+// builder has no state of its own and always operates on the one DeltaOverlay passed per call.
+// DeltaChildLookup deliberately mirrors GetParentPath's resolution order below -- keep them in sync.
+internal static class DeltaPathBuilder
+{
+    // Same Path.Combine chain as Snapshot.GetFullPath, with delta overrides patched in along the walk.
+    // Stepping onto a renamed-away row forwards to the FRN's live row (delta or base); with no live
+    // row yet, the accumulated tail hangs off the source root, like the old engine's re-orphaned rows.
+    public static string GetFullPath(DeltaOverlay o, int baseRow)
+    {
+        var segments = new List<string>(8);
+        var current = baseRow;
+        for (var depth = 0; depth < 512; depth++)
+        {
+            if (o.RenamedAway.TryGetValue(current, out var awayFrn))
+            {
+                if (o.FindAddedDirectory(awayFrn) is { } liveRecord)
+                    return AppendSegments(GetFullPath(o, liveRecord), segments);
+                if (o.TryFindLiveBaseDirectory(awayFrn, out var liveRow) && liveRow != current)
+                {
+                    current = liveRow;
+                    continue;
+                }
+                return AppendSegments(o.Snapshot.SourceRoot, segments);
+            }
+
+            var parent = o.ParentOf(current);
+            segments.Add(o.NameOf(current));
+            if (parent < 0 || parent == current)
+                break;
+            current = parent;
+        }
+        return AppendSegments(o.Snapshot.SourceRoot, segments);
+    }
+
+    internal static string GetFullPath(DeltaOverlay o, DeltaOverlay.DeltaRecord record)
+    {
+        // The eagerly-resolved parent row only counts while it is still LIVE -- a tombstoned/renamed-
+        // away parent falls through to FRN re-resolution, and with no live heir the record hangs off
+        // the source root exactly like a re-orphaned old-engine row.
+        var parentPath = GetParentPath(o, record);
+        return parentPath[^1] == '\\' ? parentPath + record.Name : parentPath + "\\" + record.Name;
+    }
+
+    // The resolved directory path a DeltaRecord's parent link currently points at -- exposed
+    // separately from GetFullPath(record) so path-mode search can run its own directory-segment
+    // matching against it without reconstructing it via string surgery on the child's full path.
+    internal static string GetParentPath(DeltaOverlay o, DeltaOverlay.DeltaRecord record)
+    {
+        if (record.ParentBaseRow >= 0 && !o.DeletedBase.Contains(record.ParentBaseRow) && !o.RenamedAway.ContainsKey(record.ParentBaseRow))
+            return GetFullPath(o, record.ParentBaseRow);
+        if (o.TryFindLiveBaseDirectory(record.ParentFrn, out var baseRow))
+            return GetFullPath(o, baseRow);
+        if (o.FindAddedDirectory(record.ParentFrn) is { } parentRecord)
+            return GetFullPath(o, parentRecord);
+        return o.Snapshot.SourceRoot;
+    }
+
+    private static string AppendSegments(string basePath, List<string> reversedSegments)
+    {
+        var builder = new System.Text.StringBuilder(basePath, 64);
+        for (var i = reversedSegments.Count - 1; i >= 0; i--)
+        {
+            if (reversedSegments[i].Length == 0)
+                continue;
+            if (builder[^1] != '\\')
+                builder.Append('\\');
+            builder.Append(reversedSegments[i]);
+        }
+        return builder.ToString();
+    }
+}

--- a/Core/IndexV2/Persistence/Snapshot.cs
+++ b/Core/IndexV2/Persistence/Snapshot.cs
@@ -62,7 +62,12 @@ public sealed unsafe class Snapshot : IDisposable
             using var headerStream = _mmf.CreateViewStream(0, 0, MemoryMappedFileAccess.Read);
             using var reader = new BinaryReader(headerStream, SnapshotFormat.NameEncoding);
             Meta = SnapshotFormat.ReadHeader(reader);
-            _offsets = SnapshotFormat.ComputeSectionOffsets(Meta, out _);
+            _offsets = SnapshotFormat.ComputeSectionOffsets(Meta, out var totalLength);
+            // A truncated file (torn write / crashed checkpoint) would otherwise map fine and only blow
+            // up later with an access violation when a query walks off the end of a section -- fail at
+            // open, while the actual file size is still at hand.
+            if (stream.Length < totalLength)
+                throw new InvalidDataException($"Snapshot file is truncated: header requires {totalLength} bytes but the file holds only {stream.Length}.");
         }
         catch
         {

--- a/Core/IndexV2/Search/PathMode/PathGate.cs
+++ b/Core/IndexV2/Search/PathMode/PathGate.cs
@@ -191,10 +191,13 @@ internal sealed class PathGate
         }
         if (!AliasProviderRegistry.HasNonAscii(segment))
             return false;
+        var disabledIds = SearchContext.DisabledAliasIds;
         foreach (var provider in AliasProviderRegistry.GetActiveProviders())
         {
             try
             {
+                if (disabledIds != null && disabledIds.Contains(AliasProviderRegistry.GetProviderId(provider)))
+                    continue;
                 if (!provider.CanHandle(segment))
                     continue;
                 foreach (var alias in provider.GetAliases(segment))

--- a/Core/IndexV2/Search/PathMode/PathGateWeighting.cs
+++ b/Core/IndexV2/Search/PathMode/PathGateWeighting.cs
@@ -173,10 +173,13 @@ internal sealed class PathGateWeighting
         }
         if (!AliasProviderRegistry.HasNonAscii(segment))
             return false;
+        var disabledIds = SearchContext.DisabledAliasIds;
         foreach (var provider in AliasProviderRegistry.GetActiveProviders())
         {
             try
             {
+                if (disabledIds != null && disabledIds.Contains(AliasProviderRegistry.GetProviderId(provider)))
+                    continue;
                 if (!provider.CanHandle(segment))
                     continue;
                 foreach (var alias in provider.GetAliases(segment))

--- a/Core/IndexV2/Search/PathMode/PathSearchFuzzy.cs
+++ b/Core/IndexV2/Search/PathMode/PathSearchFuzzy.cs
@@ -29,7 +29,8 @@ internal static class PathSearchFuzzy
 
         // See NameSearch: bounded by the index, and widened so a large limit cannot overflow.
         var keep = (int)Math.Min((long)Math.Max(limit, 8) * 8, snapshot.Count + delta.Added.Count);
-        var scanKeep = Math.Min(keep * RefinementHeadroomFactor, RefinementScanCap);
+        // Widen before multiplying so a large keep cannot overflow int (see NameSearch's identical fix).
+        var scanKeep = (int)Math.Min((long)keep * RefinementHeadroomFactor, RefinementScanCap);
         var topN = new FzfTopN(scanKeep);
 
         var lastSep = pathQuery.LastIndexOf(Path.DirectorySeparatorChar);

--- a/Core/Indexer/GlobToRegex.cs
+++ b/Core/Indexer/GlobToRegex.cs
@@ -68,9 +68,9 @@ public static class GlobToRegex
                     // Match a single path segment (non-separator characters)
                     sb.Append("[^\\\\/]*");
                 }
-                else if (consecutiveStars == 2)
+                else
                 {
-                    // Match any character across multiple path segments
+                    // Two or more stars: match any character across multiple path segments
                     sb.Append(".*");
                 }
                 consecutiveStars = 0;

--- a/Core/Indexer/Mft/MftParser.cs
+++ b/Core/Indexer/Mft/MftParser.cs
@@ -50,12 +50,14 @@ internal static class MftParser
                     var hdr = rec[p++];
                     var lenBytes = hdr & 0x0F;
                     var offBytes = (hdr >> 4) & 0x0F;
-                    if (lenBytes == 0)
+                    if (lenBytes == 0 || p + lenBytes > rec.Length)
                         break;
                     var runLen = ReadLE(rec, p, lenBytes);
                     p += lenBytes;
                     if (offBytes == 0)
                         continue; // sparse hole (unexpected for $MFT)
+                    if (p + offBytes > rec.Length)
+                        break;
                     var runOff = ReadSignedLE(rec, p, offBytes);
                     p += offBytes;
                     lcn += runOff;

--- a/Core/Indexer/NetworkDrive/NetworkIndex.cs
+++ b/Core/Indexer/NetworkDrive/NetworkIndex.cs
@@ -33,8 +33,16 @@ internal sealed class NetworkIndex : IDisposable
         {
             if (_live == null)
                 return 0;
-            var (files, dirs) = _live.GetCounts();
-            return Math.Max(0, files + dirs - 1); // -1: exclude the root row itself
+            try
+            {
+                var (files, dirs) = _live.GetCounts();
+                return Math.Max(0, files + dirs - 1); // -1: exclude the root row itself
+            }
+            catch (ObjectDisposedException)
+            {
+                // Swapped out mid-poll, same as SearchStreaming below -- report empty rather than crash.
+                return 0;
+            }
         }
     }
 
@@ -238,49 +246,25 @@ internal sealed class NetworkIndex : IDisposable
     }
 
     public bool ApplyCreatedOrChanged(string root, string path, ExclusionRuleSet? exclusionRules = null)
-    {
-        if (_live == null)
-            return false;
-        try
-        {
-            var changed = false;
-            _live.Mutate((_, delta) => changed = DeltaPathApplier.ApplyCreatedOrChanged(delta, RootId, root, path, exclusionRules));
-            if (changed)
-                LastUpdated = DateTime.Now;
-            return changed;
-        }
-        catch (ObjectDisposedException)
-        {
-            return false;
-        }
-    }
+        => ApplyToLive(delta => DeltaPathApplier.ApplyCreatedOrChanged(delta, RootId, root, path, exclusionRules));
 
     public bool ApplyDeleted(string path)
-    {
-        if (_live == null)
-            return false;
-        try
-        {
-            var removed = false;
-            _live.Mutate((_, delta) => removed = DeltaPathApplier.ApplyDeleted(delta, path));
-            if (removed)
-                LastUpdated = DateTime.Now;
-            return removed;
-        }
-        catch (ObjectDisposedException)
-        {
-            return false;
-        }
-    }
+        => ApplyToLive(delta => DeltaPathApplier.ApplyDeleted(delta, path));
 
     public bool ApplyRenamed(string root, string oldPath, string newPath, ExclusionRuleSet? exclusionRules = null)
+        => ApplyToLive(delta => DeltaPathApplier.ApplyRenamed(delta, RootId, root, oldPath, newPath, exclusionRules));
+
+    // Shared tail of the three Apply* watchers above: run one mutation against the live index, stamp
+    // LastUpdated when it changed anything, and treat a mid-mutation swap-out (ObjectDisposedException,
+    // same as SearchStreaming above) as "nothing applied".
+    private bool ApplyToLive(Func<DeltaOverlay, bool> apply)
     {
         if (_live == null)
             return false;
         try
         {
             var changed = false;
-            _live.Mutate((_, delta) => changed = DeltaPathApplier.ApplyRenamed(delta, RootId, root, oldPath, newPath, exclusionRules));
+            _live.Mutate((_, delta) => changed = apply(delta));
             if (changed)
                 LastUpdated = DateTime.Now;
             return changed;

--- a/Core/Indexer/NetworkDrive/Scheduling/Scheduler.cs
+++ b/Core/Indexer/NetworkDrive/Scheduling/Scheduler.cs
@@ -144,6 +144,12 @@ internal sealed class Scheduler : IDisposable
                 {
                     break;
                 }
+                catch (ObjectDisposedException)
+                {
+                    // Same exit path as SchedulerQueueRunner: RemovePeriodicLocked/Dispose can dispose
+                    // the cts between the token check and Task.Delay, surfacing here instead.
+                    break;
+                }
             }
         }, CancellationToken.None);
     }

--- a/Plugins/CoreExtensions/Providers/InstantAnswers/CalculatorInstantProvider.cs
+++ b/Plugins/CoreExtensions/Providers/InstantAnswers/CalculatorInstantProvider.cs
@@ -48,7 +48,9 @@ public class CalculatorInstantProvider : IInstantResultProvider
                 }
                 else
                 {
-                    if (double.TryParse(numPart, out valDouble))
+                    // Invariant parse to match the rest of the provider (ScientificMathParser parses
+                    // numbers invariantly); a culture-dependent parse would read "1.5" as 15 on de-DE.
+                    if (double.TryParse(numPart, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out valDouble))
                     {
                         val = (long)valDouble;
                         parsed = true;
@@ -83,7 +85,7 @@ public class CalculatorInstantProvider : IInstantResultProvider
                 }
                 else if (targetBase == "dec")
                 {
-                    convertedResult = valDouble.ToString();
+                    convertedResult = valDouble.ToString(System.Globalization.CultureInfo.InvariantCulture);
                 }
 
                 var desc = TranslationService.Format("Calculator_BaseConv", numPart, targetName);

--- a/Plugins/CoreExtensions/Providers/InstantAnswers/EnvironmentVariableInstantProvider.cs
+++ b/Plugins/CoreExtensions/Providers/InstantAnswers/EnvironmentVariableInstantProvider.cs
@@ -217,7 +217,8 @@ public class EnvironmentVariableInstantProvider : IInstantResultProvider
     {
         if (string.IsNullOrWhiteSpace(path) || path.Length < 3) return false;
         if (path[1] != ':' || path[2] != '\\') return false;
-        var driveLetter = char.ToUpper(path[0]);
+        // Invariant to avoid the Turkish-I problem: 'i'.ToUpper() yields U+0130 in tr-TR, failing the A-Z check.
+        var driveLetter = char.ToUpperInvariant(path[0]);
         if (driveLetter < 'A' || driveLetter > 'Z') return false;
 
         try

--- a/Plugins/CoreExtensions/Providers/InstantAnswers/ScientificMathParser.cs
+++ b/Plugins/CoreExtensions/Providers/InstantAnswers/ScientificMathParser.cs
@@ -150,10 +150,8 @@ internal class ScientificMathParser
             var hexStr = _expr[start.._pos];
             return Convert.ToInt64(hexStr, 16);
         }
-        if (_pos + 1 < _expr.Length && _expr[_pos] == '0' && _expr[_pos + 1] == '0' && _expr[_pos + 1] == 'b')
-        {
-            // Note: The original parser had a slight logic error in "0b" detection where it checked index _pos+1 twice or did start+2, let's keep it safe.
-        }
+        // Binary literals (0b...) are handled right below; an older revision kept a dead
+        // "0b" detection branch here that compared _expr[_pos + 1] twice and had an empty body.
         if (_pos + 1 < _expr.Length && _expr[_pos] == '0' && _expr[_pos + 1] == 'b')
         {
             _pos += 2;

--- a/Tests/App/ViewModels/QuickPanel/QuickPanelTabStripTests.cs
+++ b/Tests/App/ViewModels/QuickPanel/QuickPanelTabStripTests.cs
@@ -87,6 +87,27 @@ public sealed class QuickPanelTabStripTests
         Assert.IsFalse(settings.Tabs.Single().Enabled, "still there, just disabled");
     }
 
+    // Ids are matched case-insensitively everywhere else in the panel (selection, settings lookups),
+    // so closing by a differently-cased id must not strand a disabled workspace's tab on the strip:
+    // the workspace is disabled either way, but an ordinal "!= " would keep the tab itself listed
+    // and, when it was the active one, leave the panel showing content its strip says is not there.
+    [TestMethod]
+    public async Task CloseTab_DifferentlyCasedId_StillClosesIt()
+    {
+        var settings = Settings(Workspace("w1"), Workspace("w2"));
+        var (vm, saves) = Build(settings);
+        await vm.RefreshAsync();
+        await vm.SelectTabAsync("w2");
+
+        await vm.CloseTabAsync("W2");
+
+        Assert.AreEqual("w1", vm.Tabs.Single(t => t.IsSelected).Id);
+        CollectionAssert.AreEqual(new[] { "w1" }, vm.Tabs.Select(t => t.Id).ToList());
+        Assert.IsFalse(settings.Tabs.Single(t => t.Id == "w2").Enabled);
+        CollectionAssert.AreEqual(new[] { "w1s" }, vm.Groups.Select(g => g.SourceId).ToList());
+        Assert.AreEqual(1, saves.Count);
+    }
+
     [TestMethod]
     public async Task CloseTab_AlreadyClosedOrUnknown_ChangesNothing()
     {

--- a/Tests/Core/IndexV2/Delta/DeltaOverlayTests.cs
+++ b/Tests/Core/IndexV2/Delta/DeltaOverlayTests.cs
@@ -197,4 +197,40 @@ public sealed class DeltaOverlayTests
             Assert.IsFalse(delta.IsVisiblyDeleted(baseRow));
         });
     }
+
+    // Regression: removing an added row decounted it, but re-upserting the same id resurrected the
+    // slot WITHOUT counting it again -- File/DirCountDelta drifted away from the visible row count.
+    [TestMethod]
+    public void Upsert_RemoveThenUpsertSameAddedId_CountsAsASingleAdd()
+    {
+        using var fixture = BuildSampleDrive();
+        fixture.Index.Mutate((_, delta) =>
+        {
+            delta.Upsert(100, 2, "new.txt", FileRecordFlags.None, 10, 0, 0, 0);
+            delta.Remove(100);
+            Assert.AreEqual(0, delta.FileCountDelta, "add then remove nets to zero");
+
+            delta.Upsert(100, 2, "new-again.txt", FileRecordFlags.None, 10, 0, 0, 0);
+
+            Assert.IsTrue(delta.Exists(100));
+            Assert.AreEqual(1, delta.FileCountDelta, "resurrection must count exactly like a fresh add");
+            Assert.AreEqual(0, delta.DirCountDelta);
+        });
+    }
+
+    [TestMethod]
+    public void Upsert_RemoveThenUpsertSameAddedIdAsDirectory_CountsTheNewTypeOnly()
+    {
+        using var fixture = BuildSampleDrive();
+        fixture.Index.Mutate((_, delta) =>
+        {
+            delta.Upsert(100, 2, "new.txt", FileRecordFlags.None, 10, 0, 0, 0);
+            delta.Remove(100);
+
+            delta.Upsert(100, 2, "newdir", FileRecordFlags.Directory, 0, 0, 0, 0);
+
+            Assert.AreEqual(0, delta.FileCountDelta, "the removed file's earlier add/remove pair nets to zero");
+            Assert.AreEqual(1, delta.DirCountDelta, "the resurrection counts as one live directory");
+        });
+    }
 }

--- a/Tests/Core/IndexV2/Persistence/SnapshotWriterTests.cs
+++ b/Tests/Core/IndexV2/Persistence/SnapshotWriterTests.cs
@@ -74,6 +74,25 @@ public sealed class SnapshotWriterTests
         Assert.AreEqual(3, snapshot.Count);
     }
 
+    // Regression: a truncated file (torn write / crashed checkpoint) used to map fine and only blow
+    // up later with an access violation when a query walked off the end of a section -- it must be
+    // rejected at open with InvalidDataException instead.
+    [TestMethod]
+    public void Open_TruncatedFile_ThrowsInvalidDataException()
+    {
+        using var dir = new TempDirectory();
+        var path = Path.Combine(dir.Path, "truncated.idx");
+
+        SnapshotWriter.Write(BuildStore(fileCount: 4), path);
+        var fullLength = new FileInfo(path).Length;
+        using (var stream = new FileStream(path, FileMode.Open, FileAccess.Write))
+        {
+            stream.SetLength(fullLength - 16); // chop bytes off the tail sections
+        }
+
+        Assert.ThrowsExactly<InvalidDataException>(() => Snapshot.Open(path));
+    }
+
     private static FileRecordStore BuildStore(int fileCount)
     {
         var store = new FileRecordStore

--- a/Tests/Core/Indexer/GlobToRegexTests.cs
+++ b/Tests/Core/Indexer/GlobToRegexTests.cs
@@ -45,6 +45,29 @@ public sealed class GlobToRegexTests
         Assert.IsFalse(regex.IsMatch(@"c:\lib\File.cs"));
     }
 
+    // Three or more stars must behave exactly like two (cross-segment ".*"), not silently match
+    // nothing -- a user typo'ing an extra star used to turn the pattern into a literal collapse.
+    [TestMethod]
+    public void Compile_TripleStar_BehavesLikeDoubleStar()
+    {
+        var regex = GlobToRegex.Compile("a***b");
+
+        Assert.IsTrue(regex.IsMatch("ab"));
+        Assert.IsTrue(regex.IsMatch("axb"));
+        Assert.IsTrue(regex.IsMatch(@"a\x\b")); // crosses path separators like ** does
+        Assert.IsFalse(regex.IsMatch("b"));
+    }
+
+    [TestMethod]
+    public void Compile_LeadingTripleStar_MatchesAcrossPathSegments()
+    {
+        var regex = GlobToRegex.Compile("***foo");
+
+        Assert.IsTrue(regex.IsMatch("foo"));
+        Assert.IsTrue(regex.IsMatch(@"deep\nested\foo"));
+        Assert.IsFalse(regex.IsMatch(@"deep\nested\foobar"));
+    }
+
     [TestMethod]
     public void Compile_QuestionMark_MatchesExactlyOneNonSeparatorCharacter()
     {

--- a/Tests/Core/Indexer/Mft/MftParserDataRunTests.cs
+++ b/Tests/Core/Indexer/Mft/MftParserDataRunTests.cs
@@ -1,0 +1,133 @@
+using Lertaro.Core.Indexer.Mft;
+
+namespace Lertaro.Core.Tests.Indexer.Mft;
+
+// Split out of MftParserTests purely to keep that file under the repo's per-file line limit; holds
+// the $DATA run-list parsing half of MftParser's coverage, including the bounds-check regressions.
+[TestClass]
+public sealed class MftParserDataRunTests
+{
+    [TestMethod]
+    public void SingleRun_ReturnsOneExtent()
+    {
+        var rec = BuildRecordWithDataRuns((runLen: 5, delta: 10));
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.HasCount(1, extents);
+        Assert.AreEqual((10L, 5L), extents[0]);
+    }
+
+    [TestMethod]
+    public void MultipleDataAttributes_AccumulatesExtentsFromAllDataAttributes()
+    {
+        var rec = BuildRecordWithDataRuns((runLen: 5, delta: 10), (runLen: 3, delta: -4));
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.HasCount(2, extents);
+        Assert.AreEqual((10L, 5L), extents[0]);
+        Assert.AreEqual((6L, 3L), extents[1]);
+    }
+
+    [TestMethod]
+    public void NoDataAttribute_ReturnsEmpty()
+    {
+        var rec = new byte[64];
+        WriteUInt16(rec, 0x14, 32);
+        WriteUInt32(rec, 32, 0xFFFFFFFF); // immediate end marker
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.IsEmpty(extents);
+    }
+
+    [TestMethod]
+    public void ResidentDataAttribute_IsSkipped()
+    {
+        const int a = 32;
+        var rec = new byte[64];
+        WriteUInt16(rec, 0x14, a);
+        WriteUInt32(rec, a, 0x80); // $DATA
+        WriteUInt32(rec, a + 4, 16); // len, next attribute would start at a+16=48
+        rec[a + 8] = 0; // resident -> condition requires ==1, so this attribute is skipped
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.IsEmpty(extents);
+    }
+
+    // Regression: a malformed run header whose length field claims more bytes than the record still
+    // holds used to read past the buffer (the inner loop lacked ParseDataRunsFromAttribute's bounds
+    // check) and could throw on a torn record.
+    [TestMethod]
+    public void RunLengthFieldRunsPastRecord_TruncatesWithoutThrowing()
+    {
+        const int a = 32;
+        const int mpOff = 63; // header byte sits at the record's last offset (95)
+        var rec = new byte[96];
+        WriteUInt16(rec, 0x14, a);
+        WriteUInt32(rec, a, 0x80);
+        WriteUInt32(rec, a + 4, 64); // attribute runs to the end of the record
+        rec[a + 8] = 1; // non-resident
+        WriteUInt16(rec, a + 0x20, mpOff);
+        rec[a + mpOff] = 0x24; // lenBytes=2, offBytes=4 -> needs 6 more bytes, only 0 remain
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.IsEmpty(extents);
+    }
+
+    [TestMethod]
+    public void RunOffsetFieldRunsPastRecord_TruncatesWithoutThrowing()
+    {
+        const int a = 32;
+        const int mpOff = 62; // header at 94, one length byte at 95, offset field would start past the end
+        var rec = new byte[96];
+        WriteUInt16(rec, 0x14, a);
+        WriteUInt32(rec, a, 0x80);
+        WriteUInt32(rec, a + 4, 64);
+        rec[a + 8] = 1; // non-resident
+        WriteUInt16(rec, a + 0x20, mpOff);
+        rec[a + mpOff] = 0x12; // lenBytes=1 (fits), offBytes=2 -> 96+2 > 96
+        rec[a + mpOff + 1] = 3; // runLen byte
+
+        var extents = MftParser.ParseDataRuns(rec);
+
+        Assert.IsEmpty(extents);
+    }
+
+    private static byte[] BuildRecordWithDataRuns(params (long runLen, long delta)[] runs)
+    {
+        const int a = 32;
+        const int mpOff = 40; // relative to a
+
+        var runBytes = new List<byte>();
+        foreach (var (runLen, delta) in runs)
+        {
+            runBytes.Add(0x11); // lenBytes=1, offBytes=1
+            runBytes.Add((byte)runLen);
+            runBytes.Add(unchecked((byte)delta));
+        }
+        runBytes.Add(0x00); // terminator
+
+        var len = mpOff + runBytes.Count + 4;
+        var recLen = a + len + 16;
+        var buf = new byte[recLen];
+
+        WriteUInt16(buf, 0x14, a);
+        WriteUInt32(buf, a, 0x80); // $DATA
+        WriteUInt32(buf, a + 4, (uint)len);
+        buf[a + 8] = 1; // non-resident
+        WriteUInt16(buf, a + 0x20, mpOff);
+        runBytes.ToArray().CopyTo(buf, a + mpOff);
+
+        return buf;
+    }
+
+    private static void WriteUInt16(byte[] buf, int offset, int value) =>
+        BitConverter.GetBytes((ushort)value).CopyTo(buf, offset);
+
+    private static void WriteUInt32(byte[] buf, int offset, uint value) =>
+        BitConverter.GetBytes(value).CopyTo(buf, offset);
+}

--- a/Tests/Core/Indexer/Mft/MftParserTests.cs
+++ b/Tests/Core/Indexer/Mft/MftParserTests.cs
@@ -42,28 +42,8 @@ public sealed class MftParserTests
         MftParser.ApplyFixup(buf, 512, 0, buf.Length);
     }
 
-    [TestMethod]
-    public void ParseDataRuns_SingleRun_ReturnsOneExtent()
-    {
-        var rec = BuildRecordWithDataRuns((runLen: 5, delta: 10));
-
-        var extents = MftParser.ParseDataRuns(rec);
-
-        Assert.HasCount(1, extents);
-        Assert.AreEqual((10L, 5L), extents[0]);
-    }
-
-    [TestMethod]
-    public void ParseDataRuns_MultipleDataAttributes_AccumulatesExtentsFromAllDataAttributes()
-    {
-        var rec = BuildRecordWithDataRuns((runLen: 5, delta: 10), (runLen: 3, delta: -4));
-
-        var extents = MftParser.ParseDataRuns(rec);
-
-        Assert.HasCount(2, extents);
-        Assert.AreEqual((10L, 5L), extents[0]);
-        Assert.AreEqual((6L, 3L), extents[1]);
-    }
+    // The $DATA run-list parsing tests live in MftParserDataRunTests (split out to keep this file
+    // under the repo's per-file line limit).
 
     [TestMethod]
     public void ParseAttributeListRecordIndexes_ResidentAttributeList_ExtractsTargetAttributeRecordIndexes()
@@ -135,33 +115,6 @@ public sealed class MftParserTests
         Assert.AreEqual(99uL, indexes[0]);
     }
 
-
-    [TestMethod]
-    public void ParseDataRuns_NoDataAttribute_ReturnsEmpty()
-    {
-        var rec = new byte[64];
-        WriteUInt16(rec, 0x14, 32);
-        WriteUInt32(rec, 32, 0xFFFFFFFF); // immediate end marker
-
-        var extents = MftParser.ParseDataRuns(rec);
-
-        Assert.IsEmpty(extents);
-    }
-
-    [TestMethod]
-    public void ParseDataRuns_ResidentDataAttribute_IsSkipped()
-    {
-        const int a = 32;
-        var rec = new byte[64];
-        WriteUInt16(rec, 0x14, a);
-        WriteUInt32(rec, a, 0x80); // $DATA
-        WriteUInt32(rec, a + 4, 16); // len, next attribute would start at a+16=48
-        rec[a + 8] = 0; // resident -> condition requires ==1, so this attribute is skipped
-
-        var extents = MftParser.ParseDataRuns(rec);
-
-        Assert.IsEmpty(extents);
-    }
 
     [TestMethod]
     public void CollectNames_StandardInfoAndFileNameAndData_PopulatesNamesAndTimestamps()
@@ -260,34 +213,6 @@ public sealed class MftParserTests
         buf[a3 + 8] = 1; // non-resident
         buf[a3 + 9] = 0; // unnamed stream
         WriteInt64(buf, a3 + 0x30, 99999); // dataSize
-
-        return buf;
-    }
-
-    private static byte[] BuildRecordWithDataRuns(params (long runLen, long delta)[] runs)
-    {
-        const int a = 32;
-        const int mpOff = 40; // relative to a
-
-        var runBytes = new List<byte>();
-        foreach (var (runLen, delta) in runs)
-        {
-            runBytes.Add(0x11); // lenBytes=1, offBytes=1
-            runBytes.Add((byte)runLen);
-            runBytes.Add(unchecked((byte)delta));
-        }
-        runBytes.Add(0x00); // terminator
-
-        var len = mpOff + runBytes.Count + 4;
-        var recLen = a + len + 16;
-        var buf = new byte[recLen];
-
-        WriteUInt16(buf, 0x14, a);
-        WriteUInt32(buf, a, 0x80); // $DATA
-        WriteUInt32(buf, a + 4, (uint)len);
-        buf[a + 8] = 1; // non-resident
-        WriteUInt16(buf, a + 0x20, mpOff);
-        WriteBytes(buf, a + mpOff, runBytes.ToArray());
 
         return buf;
     }

--- a/Tests/Core/RepositoryHygieneTests.cs
+++ b/Tests/Core/RepositoryHygieneTests.cs
@@ -32,10 +32,13 @@ public sealed class RepositoryHygieneTests
         })
         {
             // Very short or obviously generic values would fire on ordinary code; they also are not
-            // identifying, which is the thing being protected.
+            // identifying, which is the thing being protected. "admin"/"administrator" is the same
+            // case: near-universal in code and comments ("run as admin") and names no one person,
+            // but long enough to pass the length gate above.
             if (string.IsNullOrWhiteSpace(value) || value.Length < 4)
                 continue;
-            if (value.Equals("user", StringComparison.OrdinalIgnoreCase) || value.Equals("test", StringComparison.OrdinalIgnoreCase))
+            if (value.Equals("user", StringComparison.OrdinalIgnoreCase) || value.Equals("test", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("admin", StringComparison.OrdinalIgnoreCase) || value.Equals("administrator", StringComparison.OrdinalIgnoreCase))
                 continue;
             yield return (what, new Regex($@"\b{Regex.Escape(value)}\b", RegexOptions.IgnoreCase));
         }

--- a/Tests/Plugins/CoreExtensions/Providers/InstantAnswers/CalculatorInstantProviderTests.cs
+++ b/Tests/Plugins/CoreExtensions/Providers/InstantAnswers/CalculatorInstantProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Lertaro.Plugins.CoreExtensions.Providers.InstantAnswers;
 
 namespace Lertaro.Plugins.CoreExtensions.Tests.Providers.InstantAnswers;
@@ -87,6 +88,27 @@ public sealed class CalculatorInstantProviderTests
         var result = Provider.GetInstantResults("8 to oct").Single();
 
         Assert.AreEqual("010", result.ActionArgument);
+    }
+
+    [TestMethod]
+    public void GetInstantResults_DecimalToDecConversion_UnderCommaDecimalCulture_UsesInvariantDecimalSeparator()
+    {
+        // de-DE uses ',' as decimal separator; both the parse and the "dec" output must
+        // stay invariant, otherwise "1.5" would read as 15 and format back as "1,5".
+        // CurrentCulture is per-thread (AsyncLocal), so setting and restoring it here
+        // cannot leak into parallel test methods on other threads.
+        var original = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        try
+        {
+            var result = Provider.GetInstantResults("1.5 to dec").Single();
+
+            Assert.AreEqual("1.5", result.ActionArgument);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 
     [TestMethod]

--- a/Tests/Plugins/CoreExtensions/Providers/InstantAnswers/ScientificMathParserTests.cs
+++ b/Tests/Plugins/CoreExtensions/Providers/InstantAnswers/ScientificMathParserTests.cs
@@ -41,6 +41,15 @@ public sealed class ScientificMathParserTests
     [TestMethod]
     public void Parse_BinaryLiteral_ParsesAsBase2() => Assert.AreEqual(5.0, Parse("0b101"), 1e-9);
 
+    // Regression guard for a dead "0b" detection branch that compared the same index twice
+    // and had an empty body; the real 0b handling lives just below it and must keep working.
+    [TestMethod]
+    [DataRow("0b1010", 10.0)]
+    [DataRow("0b11111111", 255.0)]
+    [DataRow("0b101 + 0b10", 7.0)]
+    public void Parse_BinaryLiteral_MultiDigitAndInExpressions_ParsesAsBase2(string expr, double expected) =>
+        Assert.AreEqual(expected, Parse(expr), 1e-9);
+
     [TestMethod]
     public void Parse_ScientificNotation_ParsesCorrectly() => Assert.AreEqual(150.0, Parse("1.5e2"), 1e-9);
 


### PR DESCRIPTION
Snapshot 截断文件长度校验
MftParser 数据运行边界检查
DeltaOverlay 删除后重建的计数漂移
Scheduler / NetworkIndex.Count 的 ObjectDisposedException 防护
PathSearchFuzzy int 溢出
GlobToRegex 三个以上星号被静默丢弃
PathGate 实时别名路径未过滤 DisabledAliasIds

AppSearchPipeService 分词搜索回调竞态
单实例 Mutex 的 AbandonedMutexException（上次崩溃后无法启动）提取为 AppSingleInstance.cs
DesktopIconHitTester 改用最小进程权限、Math.Abs(int.MinValue) 溢出、QuickPanel Id 大小写不一致比较
Cli 探测失败/终端不可用时退出码 0 → 1
计算器进制转换区域设置问题（de-DE 下 "1.5 to dec" 会误读为 15）、盘符 ToUpperInvariant、数学解析器死分支删除


---

以上bug均已在本地通过构造特殊情景复现。
修复后已通过测试

那个设置的问题修复，还有备份与回滚的feat下个pr加，估计得等明天了