### PR TITLE
build(Installer): compile the x64 Setup shell as 64-bit

### DIFF
--- a/Installer/installer.iss
+++ b/Installer/installer.iss
@@ -59,6 +59,9 @@ SolidCompression=yes
 WizardStyle=modern
 ArchitecturesAllowed={#SetupArchitectures}
 ArchitecturesInstallIn64BitMode={#SetupArchitectures}
+#if Arch == "x64"
+SetupArchitecture=x64
+#endif
 PrivilegesRequired=admin
 VersionInfoVersion={#AppVersion4}
 VersionInfoTextVersion={#AppVersion}


### PR DESCRIPTION
当前安装包会被错误地检测为x86架构，而非x64