### PR TITLE
全文索引问题修复与资源占用改进

### DIFF
--- a/App/Helpers/PluginLoaderHelper.cs
+++ b/App/Helpers/PluginLoaderHelper.cs
@@ -75,11 +75,16 @@ public static class PluginLoaderHelper
 
         // Sorted here rather than at the one list that displays it, so the settings search index, which
         // builds from this same call, offers plugins in the order the page will show them.
-        return result
-            .OrderBy(p => DisplayRank(p.HasConfigFields, p.RawComponents.Any(c => c.IsToggleable)))
-            .ThenBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase)
-            .ToList();
+        return SortForDisplay(result);
     }
+
+    /// <summary>Final display order of the plugin list: fully-disabled plugins sink to the end
+    /// (they are the least actionable), then the actionable-first DisplayRank bands, then name.</summary>
+    internal static List<PluginInfoViewModel> SortForDisplay(IEnumerable<PluginInfoViewModel> plugins) => plugins
+        .OrderBy(p => p.IsFullyDisabled)
+        .ThenBy(p => DisplayRank(p.HasConfigFields, p.RawComponents.Any(c => c.IsToggleable)))
+        .ThenBy(p => p.Name, StringComparer.CurrentCultureIgnoreCase)
+        .ToList();
 
     /// <summary>Which band a plugin sorts into: what you can act on first, alphabetical within each.</summary>
     /// <remarks>

--- a/App/ViewModels/Settings/Plugins/PluginComponentViewModel.cs
+++ b/App/ViewModels/Settings/Plugins/PluginComponentViewModel.cs
@@ -1,0 +1,52 @@
+namespace Lertaro.App.ViewModels.Settings.Plugins;
+
+/// <summary>
+/// Represents a single sub-component of a plugin (action, provider, etc.) that can be enabled/disabled.
+/// Split out of PluginInfoViewModel to give the standalone component view model its own file.
+/// </summary>
+public class PluginComponentViewModel : ViewModelBase
+{
+    private bool _isEnabled;
+
+    public PluginComponentViewModel(string componentId, PluginComponentType componentType, string displayName, bool isEnabled, string description = "")
+    {
+        ComponentId = componentId;
+        ComponentType = componentType;
+        DisplayName = displayName;
+        _isEnabled = isEnabled;
+        Description = description;
+    }
+
+    /// <summary>The stable unique ID used to persist the disabled state.</summary>
+    public string ComponentId { get; }
+
+    /// <summary>The category/type of this component (strongly-typed enum).</summary>
+    public PluginComponentType ComponentType { get; }
+
+    public string DisplayName { get; }
+
+    public string Description { get; }
+
+    /// <summary>
+    /// Whether the user can toggle this component on/off.
+    /// TranslationProvider and ThemeProvider components are shown read-only and cannot be disabled.
+    /// </summary>
+    public bool IsToggleable => ComponentType != PluginComponentType.TranslationProvider && ComponentType != PluginComponentType.ThemeProvider;
+
+    /// <summary>Set once the user actually flips this checkbox. Lets Save() apply only components the
+    /// user touched in this page, instead of blindly re-asserting this snapshot's IsEnabled for every
+    /// component -- which would clobber changes made through other channels (e.g. closing a Startup
+    /// Panel tab's x button, or the Startup Panel settings page's own re-enable checkbox) in the same
+    /// Settings window session.</summary>
+    public bool IsDirty { get; private set; }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (SetProperty(ref _isEnabled, value))
+                IsDirty = true;
+        }
+    }
+}

--- a/App/ViewModels/Settings/Plugins/PluginInfoViewModel.cs
+++ b/App/ViewModels/Settings/Plugins/PluginInfoViewModel.cs
@@ -118,6 +118,10 @@ public class PluginInfoViewModel : ViewModelBase
         // so there's nothing for the plugin-wide select-all button to toggle for those.
         foreach (var component in RawComponents.Where(c => c.IsToggleable))
             component.PropertyChanged += OnComponentIsEnabledChanged;
+
+        // Snapshot without raising the event: a plugin restored from persisted settings may
+        // start out fully disabled, and the list is about to be sorted by that state anyway.
+        _isFullyDisabled = ComputeFullyDisabled();
     }
 
     public string Name { get; }
@@ -155,10 +159,40 @@ public class PluginInfoViewModel : ViewModelBase
 
     public ICommand ToggleAllComponentsCommand { get; }
 
+    /// <summary>
+    /// Raised when the plugin crosses the fully-disabled boundary (every toggleable component
+    /// off, or back on again), so the owning list can move the card to its new sort position.
+    /// </summary>
+    public event Action<PluginInfoViewModel>? FullyDisabledChanged;
+
+    private bool _isFullyDisabled;
+
+    /// <summary>
+    /// Whether every toggleable component of this plugin is currently disabled. A plugin with no
+    /// toggleable components at all (translation/theme-only) can never be "fully disabled" --
+    /// there is nothing the user turned off. Fully-disabled plugins sort after all others.
+    /// </summary>
+    public bool IsFullyDisabled
+    {
+        get => _isFullyDisabled;
+        private set
+        {
+            if (SetProperty(ref _isFullyDisabled, value))
+                FullyDisabledChanged?.Invoke(this);
+        }
+    }
+
+    private bool ComputeFullyDisabled()
+    {
+        var toggleable = RawComponents.Where(c => c.IsToggleable).ToList();
+        return toggleable.Count > 0 && toggleable.All(c => !c.IsEnabled);
+    }
+
     private void OnComponentIsEnabledChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(PluginComponentViewModel.IsEnabled))
-            OnPropertyChanged(nameof(SelectAllToggleLabel));
+        if (e.PropertyName != nameof(PluginComponentViewModel.IsEnabled)) return;
+        OnPropertyChanged(nameof(SelectAllToggleLabel));
+        IsFullyDisabled = ComputeFullyDisabled();
     }
 
     private void ToggleAllComponents()
@@ -245,52 +279,3 @@ public class PluginInfoViewModel : ViewModelBase
     public ICommand SelectConfigGroupCommand => _selectConfigGroupCommand ??= new RelayCommand<PluginConfigFieldViewModel>(g => SelectedConfigGroup = g);
 }
 
-/// <summary>
-/// Represents a single sub-component of a plugin (action, provider, etc.) that can be enabled/disabled.
-/// </summary>
-public class PluginComponentViewModel : ViewModelBase
-{
-    private bool _isEnabled;
-
-    public PluginComponentViewModel(string componentId, PluginComponentType componentType, string displayName, bool isEnabled, string description = "")
-    {
-        ComponentId = componentId;
-        ComponentType = componentType;
-        DisplayName = displayName;
-        _isEnabled = isEnabled;
-        Description = description;
-    }
-
-    /// <summary>The stable unique ID used to persist the disabled state.</summary>
-    public string ComponentId { get; }
-
-    /// <summary>The category/type of this component (strongly-typed enum).</summary>
-    public PluginComponentType ComponentType { get; }
-
-    public string DisplayName { get; }
-
-    public string Description { get; }
-
-    /// <summary>
-    /// Whether the user can toggle this component on/off.
-    /// TranslationProvider and ThemeProvider components are shown read-only and cannot be disabled.
-    /// </summary>
-    public bool IsToggleable => ComponentType != PluginComponentType.TranslationProvider && ComponentType != PluginComponentType.ThemeProvider;
-
-    /// <summary>Set once the user actually flips this checkbox. Lets Save() apply only components the
-    /// user touched in this page, instead of blindly re-asserting this snapshot's IsEnabled for every
-    /// component -- which would clobber changes made through other channels (e.g. closing a Startup
-    /// Panel tab's x button, or the Startup Panel settings page's own re-enable checkbox) in the same
-    /// Settings window session.</summary>
-    public bool IsDirty { get; private set; }
-
-    public bool IsEnabled
-    {
-        get => _isEnabled;
-        set
-        {
-            if (SetProperty(ref _isEnabled, value))
-                IsDirty = true;
-        }
-    }
-}

--- a/App/ViewModels/Settings/Plugins/PluginManagementViewModel.cs
+++ b/App/ViewModels/Settings/Plugins/PluginManagementViewModel.cs
@@ -22,6 +22,7 @@ public class PluginManagementViewModel : ViewModelBase
         Plugins = new ObservableCollection<PluginInfoViewModel>(PluginLoaderHelper.BuildPluginList(_userSettings));
         SaveConfigCommand = new RelayCommand<PluginInfoViewModel>(SaveConfig);
         _selectedPlugin = Plugins.FirstOrDefault();
+        AttachFullyDisabledWatch();
 
         // Dynamically refresh the plugin list when language changes to dynamically apply localized plugin names
         TranslationManager.Instance.PropertyChanged += (s, e) =>
@@ -34,12 +35,56 @@ public class PluginManagementViewModel : ViewModelBase
             foreach (var p in newList)
                 Plugins.Add(p);
             SelectedPlugin = Plugins.FirstOrDefault(p => p.DllFileName == selectedDll) ?? Plugins.FirstOrDefault();
+            AttachFullyDisabledWatch();
             OnPropertyChanged(nameof(IsEmpty));
             OnPropertyChanged(nameof(DevGuideUri));
         };
     }
 
     public ObservableCollection<PluginInfoViewModel> Plugins { get; }
+
+    // Toggling a plugin's last components off (or back on) moves its card to its sorted position
+    // in place, instead of waiting for the next rebuild.
+    private void AttachFullyDisabledWatch()
+    {
+        foreach (var plugin in Plugins)
+            plugin.FullyDisabledChanged += p => MovePluginForDisabledState(Plugins, p);
+    }
+
+    internal static void MovePluginForDisabledState(ObservableCollection<PluginInfoViewModel> plugins, PluginInfoViewModel plugin)
+    {
+        var currentIndex = plugins.IndexOf(plugin);
+        if (currentIndex < 0) return;
+
+        // Remove first, then re-insert at the first position that sorts after the moved plugin:
+        // that is exactly where SortForDisplay would have put it, in the disabled tail as well
+        // as back among the active band. No position found means it belongs at the end.
+        plugins.RemoveAt(currentIndex);
+
+        var insertAt = plugins.Count;
+        for (var i = 0; i < plugins.Count; i++)
+        {
+            if (CompareDisplayOrder(plugins[i], plugin) > 0)
+            {
+                insertAt = i;
+                break;
+            }
+        }
+
+        plugins.Insert(insertAt, plugin);
+    }
+
+    private static int CompareDisplayOrder(PluginInfoViewModel left, PluginInfoViewModel right)
+    {
+        var byDisabled = left.IsFullyDisabled.CompareTo(right.IsFullyDisabled);
+        if (byDisabled != 0) return byDisabled;
+
+        var byRank = PluginLoaderHelper.DisplayRank(left.HasConfigFields, left.RawComponents.Any(c => c.IsToggleable))
+            .CompareTo(PluginLoaderHelper.DisplayRank(right.HasConfigFields, right.RawComponents.Any(c => c.IsToggleable)));
+        if (byRank != 0) return byRank;
+
+        return string.Compare(left.Name, right.Name, StringComparison.CurrentCultureIgnoreCase);
+    }
 
     private PluginInfoViewModel? _selectedPlugin;
 

--- a/Plugins/ContentSearch/ContentSearchPlugin.cs
+++ b/Plugins/ContentSearch/ContentSearchPlugin.cs
@@ -78,7 +78,7 @@ public sealed class ContentSearchPlugin : IPlugin, IConfigurable
                 LabelKey = "ContentSearch_Config_ExtensionsLabel",
                 DescriptionKey = "ContentSearch_Config_ExtensionsDesc",
                 FieldType = ConfigFieldType.Text,
-                DefaultValue = "txt,md,pdf,docx,pptx,xlsx,csv"
+                DefaultValue = "txt,md,pdf,docx,docm,pptx,pptm,xlsx,xlsm,csv"
             }
         },
         OnSave = () =>

--- a/Plugins/ContentSearch/Extraction/DocxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/DocxExtractor.cs
@@ -5,7 +5,9 @@ using System.Xml.Linq;
 namespace Lertaro.Plugins.ContentSearch.Extraction;
 
 /// <summary>
-/// Extracts readable text from Word (.docx) documents using built-in ZipArchive and XML parsing.
+/// Extracts searchable text from Word (.docx/.docm) documents using built-in ZipArchive and XML parsing.
+/// Covers the body plus footnotes, endnotes, comments, headers, and footers, mirroring the parts
+/// dnGrep's WordReader extracts; those parts live in separate zip entries that a body-only read misses.
 /// </summary>
 public sealed class DocxExtractor : ITextExtractor
 {
@@ -13,7 +15,8 @@ public sealed class DocxExtractor : ITextExtractor
     private static readonly XNamespace WordNs = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
 
     public bool CanHandle(string extension) =>
-        string.Equals(extension, ".docx", StringComparison.OrdinalIgnoreCase);
+        string.Equals(extension, ".docx", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(extension, ".docm", StringComparison.OrdinalIgnoreCase);
 
     public async Task<string?> ExtractTextAsync(string filePath, long maxFileSizeBytes, CancellationToken cancellationToken = default)
     {
@@ -31,41 +34,125 @@ public sealed class DocxExtractor : ITextExtractor
                 timeoutCts.Token.ThrowIfCancellationRequested();
                 using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read, leaveOpen: false);
-
-                var docEntry = archive.GetEntry("word/document.xml");
-                if (docEntry == null)
-                    return null;
-
-                using var docStream = docEntry.Open();
-                var xDoc = XDocument.Load(docStream);
-                if (xDoc.Root == null)
-                    return null;
-
-                var builder = new StringBuilder();
-                foreach (var paragraph in xDoc.Descendants(WordNs + "p"))
-                {
-                    timeoutCts.Token.ThrowIfCancellationRequested();
-                    var pText = new StringBuilder();
-                    foreach (var textElem in paragraph.Descendants(WordNs + "t"))
-                    {
-                        pText.Append(textElem.Value);
-                    }
-
-                    if (pText.Length > 0)
-                    {
-                        builder.AppendLine(pText.ToString());
-                    }
-
-                    if (builder.Length >= MaxExtractedCharacters)
-                        break;
-                }
-
-                return builder.Length > 0 ? builder.ToString() : null;
+                return ExtractDocumentText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
         catch
         {
             return null;
         }
+    }
+
+    private static string? ExtractDocumentText(ZipArchive archive, CancellationToken ct)
+    {
+        var builder = new StringBuilder();
+
+        AppendParagraphsFromEntry(archive.GetEntry("word/document.xml"), builder, ct);
+        AppendNoteParts(archive.GetEntry("word/footnotes.xml"), "footnote", builder, ct);
+        AppendNoteParts(archive.GetEntry("word/endnotes.xml"), "endnote", builder, ct);
+        AppendCommentParts(archive.GetEntry("word/comments.xml"), builder, ct);
+        AppendPrefixedParts(archive, "word/header", builder, ct);
+        AppendPrefixedParts(archive, "word/footer", builder, ct);
+
+        return builder.Length > 0 ? builder.ToString() : null;
+    }
+
+    private static void AppendParagraphsFromEntry(ZipArchiveEntry? entry, StringBuilder builder, CancellationToken ct)
+    {
+        if (entry == null) return;
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        if (xDoc.Root == null) return;
+
+        foreach (var paragraph in xDoc.Descendants(WordNs + "p"))
+        {
+            ct.ThrowIfCancellationRequested();
+            AppendParagraphText(paragraph, builder);
+            if (builder.Length >= MaxExtractedCharacters)
+                return;
+        }
+    }
+
+    private static void AppendNoteParts(ZipArchiveEntry? entry, string noteElementName, StringBuilder builder, CancellationToken ct)
+    {
+        if (entry == null) return;
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        if (xDoc.Root == null) return;
+
+        // Notes with ids 0 and -1 hold the separator and continuation marks, not real content.
+        foreach (var note in xDoc.Descendants(WordNs + noteElementName))
+        {
+            if (!long.TryParse(note.Attribute(WordNs + "id")?.Value, out var id) || id <= 0)
+                continue;
+
+            foreach (var paragraph in note.Descendants(WordNs + "p"))
+            {
+                ct.ThrowIfCancellationRequested();
+                AppendParagraphText(paragraph, builder);
+                if (builder.Length >= MaxExtractedCharacters)
+                    return;
+            }
+        }
+    }
+
+    private static void AppendCommentParts(ZipArchiveEntry? entry, StringBuilder builder, CancellationToken ct)
+    {
+        if (entry == null) return;
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        if (xDoc.Root == null) return;
+
+        foreach (var comment in xDoc.Descendants(WordNs + "comment"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var author = comment.Attribute(WordNs + "author")?.Value;
+            if (!string.IsNullOrWhiteSpace(author))
+                builder.AppendLine(author.Trim());
+
+            foreach (var paragraph in comment.Descendants(WordNs + "p"))
+            {
+                AppendParagraphText(paragraph, builder);
+            }
+
+            if (builder.Length >= MaxExtractedCharacters)
+                return;
+        }
+    }
+
+    private static void AppendPrefixedParts(ZipArchive archive, string entryNamePrefix, StringBuilder builder, CancellationToken ct)
+    {
+        var entries = archive.Entries
+            .Where(e => e.FullName.StartsWith(entryNamePrefix, StringComparison.OrdinalIgnoreCase) &&
+                        e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var entry in entries)
+        {
+            AppendParagraphsFromEntry(entry, builder, ct);
+            if (builder.Length >= MaxExtractedCharacters)
+                return;
+        }
+    }
+
+    private static void AppendParagraphText(XElement paragraph, StringBuilder builder)
+    {
+        var text = new StringBuilder();
+        foreach (var node in paragraph.Descendants())
+        {
+            if (node.Name == WordNs + "t")
+                text.Append(node.Value);
+            else if (node.Name == WordNs + "tab")
+                text.Append('\t');
+            else if (node.Name == WordNs + "br")
+                text.Append(' ');
+            else if (node.Name == WordNs + "noBreakHyphen")
+                text.Append('\u2011');
+        }
+
+        if (text.Length > 0)
+            builder.AppendLine(text.ToString());
     }
 }

--- a/Plugins/ContentSearch/Extraction/DocxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/DocxExtractor.cs
@@ -37,8 +37,11 @@ public sealed class DocxExtractor : ITextExtractor
                 return ExtractDocumentText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
-        catch
+        catch (Exception ex)
         {
+            PluginSdk.Logger.Log(
+                $"[ContentSearch] Failed to extract Word document '{filePath}': {ex.Message}",
+                PluginSdk.LogLevel.Warn);
             return null;
         }
     }

--- a/Plugins/ContentSearch/Extraction/PdfExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PdfExtractor.cs
@@ -49,8 +49,11 @@ public sealed class PdfExtractor : ITextExtractor
                     {
                         throw;
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        PluginSdk.Logger.Log(
+                            $"[ContentSearch] PDF page {pageNumber} of '{filePath}' failed to process, skipping: {ex.Message}",
+                            PluginSdk.LogLevel.Warn);
                         continue;
                     }
 
@@ -66,8 +69,11 @@ public sealed class PdfExtractor : ITextExtractor
                 return builder.Length > 0 ? builder.ToString() : null;
             }, timeoutCts.Token);
         }
-        catch
+        catch (Exception ex)
         {
+            PluginSdk.Logger.Log(
+                $"[ContentSearch] Failed to extract PDF '{filePath}': {ex.Message}",
+                PluginSdk.LogLevel.Warn);
             return null;
         }
     }

--- a/Plugins/ContentSearch/Extraction/PdfExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PdfExtractor.cs
@@ -32,17 +32,34 @@ public sealed class PdfExtractor : ITextExtractor
                 using var document = PdfDocument.Open(fileStream);
 
                 var builder = new StringBuilder();
-                var pageCount = 0;
-
-                foreach (var page in document.GetPages())
+                for (var pageNumber = 1; pageNumber <= document.NumberOfPages; pageNumber++)
                 {
                     timeoutCts.Token.ThrowIfCancellationRequested();
-                    if (!string.IsNullOrWhiteSpace(page.Text))
+
+                    // Some PDFs draw glyphs on a slightly rotated text matrix (e.g. 4 degrees);
+                    // PdfPig 0.1.9 throws from Letter.GetTextOrientationRot while processing such
+                    // a page. One bad page must not void the whole document, so isolate each page
+                    // and skip the ones that fail to process.
+                    string? pageText;
+                    try
                     {
-                        builder.AppendLine(page.Text);
+                        pageText = document.GetPage(pageNumber).Text;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
+                    catch
+                    {
+                        continue;
                     }
 
-                    if (++pageCount >= MaxPagesToExtract || builder.Length >= MaxExtractedCharacters)
+                    if (!string.IsNullOrWhiteSpace(pageText))
+                    {
+                        builder.AppendLine(pageText);
+                    }
+
+                    if (pageNumber >= MaxPagesToExtract || builder.Length >= MaxExtractedCharacters)
                         break;
                 }
 

--- a/Plugins/ContentSearch/Extraction/PlainTextExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PlainTextExtractor.cs
@@ -1,10 +1,18 @@
+using System.Text;
+
 namespace Lertaro.Plugins.ContentSearch.Extraction;
 
 /// <summary>
-/// Extracts plain text from document and code files using UTF-8 reading.
+/// Extracts plain text from document and code files, honoring BOMs and falling back to
+/// GB18030 (superset of GBK/GB2312) for legacy Chinese-encoded files.
 /// </summary>
 public sealed class PlainTextExtractor : ITextExtractor
 {
+    static PlainTextExtractor() =>
+        // GB18030 is not in the default .NET Core encoding set; the code pages provider
+        // ships in the shared framework and only needs registering once per process.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
     public bool CanHandle(string extension) => !string.IsNullOrWhiteSpace(extension);
 
     public async Task<string?> ExtractTextAsync(string filePath, long maxFileSizeBytes, CancellationToken cancellationToken = default)
@@ -15,11 +23,35 @@ public sealed class PlainTextExtractor : ITextExtractor
             if (!fileInfo.Exists || fileInfo.Length > maxFileSizeBytes || fileInfo.Length == 0)
                 return null;
 
-            return await File.ReadAllTextAsync(filePath, cancellationToken);
+            var bytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+            return DecodeText(bytes);
         }
         catch
         {
             return null;
+        }
+    }
+
+    internal static string DecodeText(byte[] bytes)
+    {
+        if (bytes.Length == 0) return string.Empty;
+
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            return new UTF8Encoding(false).GetString(bytes, 3, bytes.Length - 3);
+        if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+            return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+        if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+            return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+
+        try
+        {
+            // Strict UTF-8 first: a UTF-8 file must never be misread as GB18030, while a
+            // GBK file virtually always contains byte sequences that are invalid UTF-8.
+            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetString(bytes);
+        }
+        catch (DecoderFallbackException)
+        {
+            return Encoding.GetEncoding("GB18030").GetString(bytes);
         }
     }
 }

--- a/Plugins/ContentSearch/Extraction/PlainTextExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PlainTextExtractor.cs
@@ -5,9 +5,16 @@ namespace Lertaro.Plugins.ContentSearch.Extraction;
 /// <summary>
 /// Extracts plain text from document and code files, honoring BOMs and falling back to
 /// GB18030 (superset of GBK/GB2312) for legacy Chinese-encoded files.
+/// Binary files with no dedicated extractor (e.g. .doc, .exe typed into the whitelist) are
+/// detected and skipped so their bytes never reach the index as mojibake.
 /// </summary>
 public sealed class PlainTextExtractor : ITextExtractor
 {
+    // A NUL byte in the leading chunk is the standard binary tell (git uses the same):
+    // real text never contains one, while OLE (.doc/.xls) and PE (.exe) headers have many.
+    // BOM'd UTF-16 is exempted first since its text is NUL-interleaved.
+    private const int BinaryProbeLength = 8192;
+
     static PlainTextExtractor() =>
         // GB18030 is not in the default .NET Core encoding set; the code pages provider
         // ships in the shared framework and only needs registering once per process.
@@ -24,13 +31,32 @@ public sealed class PlainTextExtractor : ITextExtractor
                 return null;
 
             var bytes = await File.ReadAllBytesAsync(filePath, cancellationToken);
+
+            if (!HasUnicodeBom(bytes) && LooksBinary(bytes))
+            {
+                PluginSdk.Logger.Log(
+                    $"[ContentSearch] Skipped binary file (no dedicated extractor): '{filePath}'",
+                    PluginSdk.LogLevel.Warn);
+                return null;
+            }
+
             return DecodeText(bytes);
         }
-        catch
+        catch (Exception ex)
         {
+            PluginSdk.Logger.Log(
+                $"[ContentSearch] Failed to extract text from '{filePath}': {ex.Message}",
+                PluginSdk.LogLevel.Warn);
             return null;
         }
     }
+
+    internal static bool LooksBinary(byte[] bytes) =>
+        Array.IndexOf(bytes, (byte)0, 0, Math.Min(bytes.Length, BinaryProbeLength)) >= 0;
+
+    internal static bool HasUnicodeBom(ReadOnlySpan<byte> bytes) =>
+        (bytes.Length >= 2 && ((bytes[0] == 0xFF && bytes[1] == 0xFE) || (bytes[0] == 0xFE && bytes[1] == 0xFF))) ||
+        (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
 
     internal static string DecodeText(byte[] bytes)
     {

--- a/Plugins/ContentSearch/Extraction/PptxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PptxExtractor.cs
@@ -37,8 +37,11 @@ public sealed class PptxExtractor : ITextExtractor
                 return ExtractPresentationText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
-        catch
+        catch (Exception ex)
         {
+            PluginSdk.Logger.Log(
+                $"[ContentSearch] Failed to extract presentation '{filePath}': {ex.Message}",
+                PluginSdk.LogLevel.Warn);
             return null;
         }
     }

--- a/Plugins/ContentSearch/Extraction/PptxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/PptxExtractor.cs
@@ -5,7 +5,9 @@ using System.Xml.Linq;
 namespace Lertaro.Plugins.ContentSearch.Extraction;
 
 /// <summary>
-/// Extracts readable slide text from PowerPoint (.pptx) presentations using built-in ZipArchive and DrawingML parsing.
+/// Extracts searchable slide text from PowerPoint (.pptx) presentations using built-in ZipArchive and
+/// DrawingML parsing. Covers speaker notes slides in addition to the slides themselves, mirroring
+/// dnGrep's PowerPointReader; notes live in separate zip entries that a slides-only read misses.
 /// </summary>
 public sealed class PptxExtractor : ITextExtractor
 {
@@ -32,43 +34,7 @@ public sealed class PptxExtractor : ITextExtractor
                 timeoutCts.Token.ThrowIfCancellationRequested();
                 using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read, leaveOpen: false);
-
-                var builder = new StringBuilder();
-
-                var slideEntries = archive.Entries
-                    .Where(e => e.FullName.StartsWith("ppt/slides/slide", StringComparison.OrdinalIgnoreCase) &&
-                                e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(e => e.FullName, StringComparer.OrdinalIgnoreCase);
-
-                foreach (var entry in slideEntries)
-                {
-                    timeoutCts.Token.ThrowIfCancellationRequested();
-                    using var slideStream = entry.Open();
-                    var xDoc = XDocument.Load(slideStream);
-                    if (xDoc.Root == null) continue;
-
-                    foreach (var paragraph in xDoc.Descendants(DrawingNs + "p"))
-                    {
-                        var pText = new StringBuilder();
-                        foreach (var textElem in paragraph.Descendants(DrawingNs + "t"))
-                        {
-                            pText.Append(textElem.Value);
-                        }
-
-                        if (pText.Length > 0)
-                        {
-                            builder.AppendLine(pText.ToString());
-                        }
-
-                        if (builder.Length >= MaxExtractedCharacters)
-                            break;
-                    }
-
-                    if (builder.Length >= MaxExtractedCharacters)
-                        break;
-                }
-
-                return builder.Length > 0 ? builder.ToString() : null;
+                return ExtractPresentationText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
         catch
@@ -76,4 +42,71 @@ public sealed class PptxExtractor : ITextExtractor
             return null;
         }
     }
+
+    private static string? ExtractPresentationText(ZipArchive archive, CancellationToken ct)
+    {
+        var builder = new StringBuilder();
+
+        foreach (var entry in SlidesOrNotes(archive, "ppt/slides/slide"))
+        {
+            ct.ThrowIfCancellationRequested();
+            AppendSlideText(entry, builder, ct, skipSlideNumberFields: false);
+            if (builder.Length >= MaxExtractedCharacters)
+                return builder.ToString();
+        }
+
+        foreach (var entry in SlidesOrNotes(archive, "ppt/notesSlides/notesSlide"))
+        {
+            ct.ThrowIfCancellationRequested();
+            AppendSlideText(entry, builder, ct, skipSlideNumberFields: true);
+            if (builder.Length >= MaxExtractedCharacters)
+                return builder.ToString();
+        }
+
+        return builder.Length > 0 ? builder.ToString() : null;
+    }
+
+    private static IEnumerable<ZipArchiveEntry> SlidesOrNotes(ZipArchive archive, string entryNamePrefix) =>
+        archive.Entries
+            .Where(e => e.FullName.StartsWith(entryNamePrefix, StringComparison.OrdinalIgnoreCase) &&
+                        e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(e => e.FullName, StringComparer.OrdinalIgnoreCase);
+
+    private static void AppendSlideText(ZipArchiveEntry entry, StringBuilder builder, CancellationToken ct, bool skipSlideNumberFields)
+    {
+        using var slideStream = entry.Open();
+        var xDoc = XDocument.Load(slideStream);
+        if (xDoc.Root == null) return;
+
+        foreach (var paragraph in xDoc.Descendants(DrawingNs + "p"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var text = new StringBuilder();
+            foreach (var node in paragraph.Descendants())
+            {
+                if (node.Name == DrawingNs + "t")
+                {
+                    // Notes slides repeat the slide number field on every page; indexing it
+                    // would pollute the full-text index with meaningless page counters.
+                    if (skipSlideNumberFields && IsSlideNumberField(node))
+                        continue;
+                    text.Append(node.Value);
+                }
+                else if (node.Name == DrawingNs + "br")
+                {
+                    text.Append(' ');
+                }
+            }
+
+            if (text.Length > 0)
+                builder.AppendLine(text.ToString());
+
+            if (builder.Length >= MaxExtractedCharacters)
+                return;
+        }
+    }
+
+    private static bool IsSlideNumberField(XElement textElement) =>
+        textElement.Ancestors(DrawingNs + "fld")
+            .Any(fld => (string?)fld.Attribute("type") == "slidenum");
 }

--- a/Plugins/ContentSearch/Extraction/XlsxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/XlsxExtractor.cs
@@ -47,8 +47,11 @@ public sealed class XlsxExtractor : ITextExtractor
                 return ExtractWorkbookText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
-        catch
+        catch (Exception ex)
         {
+            PluginSdk.Logger.Log(
+                $"[ContentSearch] Failed to extract workbook '{filePath}': {ex.Message}",
+                PluginSdk.LogLevel.Warn);
             return null;
         }
     }

--- a/Plugins/ContentSearch/Extraction/XlsxExtractor.cs
+++ b/Plugins/ContentSearch/Extraction/XlsxExtractor.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 using System.Xml.Linq;
@@ -5,12 +6,23 @@ using System.Xml.Linq;
 namespace Lertaro.Plugins.ContentSearch.Extraction;
 
 /// <summary>
-/// Extracts readable spreadsheet text from Excel (.xlsx) workbooks using built-in ZipArchive and XML parsing.
+/// Extracts searchable text from Excel (.xlsx) workbooks using built-in ZipArchive and XML parsing.
+/// Text cells are resolved through the shared strings table; numeric cells are read from the
+/// sheet's cached values; date-styled cells are normalized to ISO yyyy-MM-dd so date text is searchable.
 /// </summary>
 public sealed class XlsxExtractor : ITextExtractor
 {
     private const int MaxExtractedCharacters = 500_000;
     private static readonly XNamespace SpreadsheetNs = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    // Excel serial dates below 61 involve the fictional 1900-02-29 leap day kept for Lotus
+    // compatibility; anchoring at 1899-12-30 is exact for every modern date and only mis-dates
+    // serials 1-59 by a day, which is irrelevant for search.
+    private static readonly DateTime Epoch1900 = new(1899, 12, 30);
+    private static readonly DateTime Epoch1904 = new(1904, 1, 1);
+
+    // Built-in number-format ids that render a date; 18-21 and 45-47 render times only.
+    private static readonly HashSet<int> BuiltInDateFormats = new() { 14, 15, 16, 17, 22 };
 
     public bool CanHandle(string extension) =>
         string.Equals(extension, ".xlsx", StringComparison.OrdinalIgnoreCase) ||
@@ -32,71 +44,188 @@ public sealed class XlsxExtractor : ITextExtractor
                 timeoutCts.Token.ThrowIfCancellationRequested();
                 using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read, leaveOpen: false);
-
-                var builder = new StringBuilder();
-
-                var stringsEntry = archive.GetEntry("xl/sharedStrings.xml");
-                if (stringsEntry != null)
-                {
-                    using var stream = stringsEntry.Open();
-                    var xDoc = XDocument.Load(stream);
-                    if (xDoc.Root != null)
-                    {
-                        foreach (var stringItem in xDoc.Descendants(SpreadsheetNs + "si"))
-                        {
-                            timeoutCts.Token.ThrowIfCancellationRequested();
-                            var rowText = new StringBuilder();
-                            foreach (var textElem in stringItem.Descendants(SpreadsheetNs + "t"))
-                            {
-                                rowText.Append(textElem.Value);
-                            }
-
-                            if (rowText.Length > 0)
-                            {
-                                builder.AppendLine(rowText.ToString());
-                            }
-
-                            if (builder.Length >= MaxExtractedCharacters)
-                                break;
-                        }
-                    }
-                }
-
-                if (builder.Length == 0)
-                {
-                    var sheetEntries = archive.Entries
-                        .Where(e => e.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) &&
-                                    e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase));
-
-                    foreach (var entry in sheetEntries)
-                    {
-                        timeoutCts.Token.ThrowIfCancellationRequested();
-                        using var sheetStream = entry.Open();
-                        var xDoc = XDocument.Load(sheetStream);
-                        if (xDoc.Root == null) continue;
-
-                        foreach (var textElem in xDoc.Descendants(SpreadsheetNs + "t"))
-                        {
-                            if (!string.IsNullOrWhiteSpace(textElem.Value))
-                            {
-                                builder.AppendLine(textElem.Value);
-                            }
-
-                            if (builder.Length >= MaxExtractedCharacters)
-                                break;
-                        }
-
-                        if (builder.Length >= MaxExtractedCharacters)
-                            break;
-                    }
-                }
-
-                return builder.Length > 0 ? builder.ToString() : null;
+                return ExtractWorkbookText(archive, timeoutCts.Token);
             }, timeoutCts.Token);
         }
         catch
         {
             return null;
         }
+    }
+
+    private static string? ExtractWorkbookText(ZipArchive archive, CancellationToken ct)
+    {
+        var sharedStrings = ReadSharedStrings(archive);
+        var (xfNumberFormats, customFormats) = ReadNumberFormats(archive);
+        var date1904 = ReadDate1904Flag(archive);
+
+        var builder = new StringBuilder();
+        var sheetEntries = archive.Entries
+            .Where(e => e.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) &&
+                        e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var entry in sheetEntries)
+        {
+            ct.ThrowIfCancellationRequested();
+            using var sheetStream = entry.Open();
+            var xDoc = XDocument.Load(sheetStream);
+            if (xDoc.Root == null) continue;
+
+            foreach (var cell in xDoc.Descendants(SpreadsheetNs + "c"))
+            {
+                ct.ThrowIfCancellationRequested();
+                var cellText = GetCellText(cell, sharedStrings, xfNumberFormats, customFormats, date1904);
+                if (string.IsNullOrWhiteSpace(cellText))
+                    continue;
+
+                // Flatten in-cell line breaks to spaces (same as dnGrep) so a single cell's
+                // phrase stays contiguous for trigram matching.
+                builder.AppendLine(cellText.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' '));
+                if (builder.Length >= MaxExtractedCharacters)
+                    return builder.ToString();
+            }
+        }
+
+        return builder.Length > 0 ? builder.ToString() : null;
+    }
+
+    private static string? GetCellText(
+        XElement cell,
+        List<string> sharedStrings,
+        List<int> xfNumberFormats,
+        Dictionary<int, string> customFormats,
+        bool date1904)
+    {
+        var type = (string?)cell.Attribute("t");
+        var value = cell.Element(SpreadsheetNs + "v")?.Value;
+
+        switch (type)
+        {
+            case "s":
+                return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index) &&
+                       index >= 0 && index < sharedStrings.Count
+                    ? sharedStrings[index]
+                    : null;
+            case "inlineStr":
+                return ConcatText(cell.Element(SpreadsheetNs + "is"));
+            case "str":
+            case "d":
+                return value;
+            case "b":
+                return value == "1" ? "TRUE" : value == "0" ? "FALSE" : null;
+            case "e":
+                return null;
+        }
+
+        // Numeric (t absent or "n"): dates are numbers styled with a date format.
+        if (value != null && IsDateStyled(cell, xfNumberFormats, customFormats))
+        {
+            return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var serial)
+                ? SerialToIsoDate(serial, date1904)
+                : value;
+        }
+
+        return value;
+    }
+
+    private static bool IsDateStyled(XElement cell, List<int> xfNumberFormats, Dictionary<int, string> customFormats)
+    {
+        if (!int.TryParse(cell.Attribute("s")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var styleIndex) ||
+            styleIndex < 0 || styleIndex >= xfNumberFormats.Count)
+        {
+            return false;
+        }
+
+        return IsDateFormat(xfNumberFormats[styleIndex], customFormats);
+    }
+
+    internal static bool IsDateFormat(int numberFormatId, Dictionary<int, string> customFormats)
+    {
+        if (BuiltInDateFormats.Contains(numberFormatId))
+            return true;
+
+        // Custom formats are dates when their code renders y/d/h/s parts (m alone often is a
+        // literal or month-only token, so it is not enough on its own).
+        return customFormats.TryGetValue(numberFormatId, out var code) &&
+               (code.Contains('y') || code.Contains('d') || code.Contains('h') || code.Contains('s'));
+    }
+
+    internal static string SerialToIsoDate(double serial, bool date1904)
+    {
+        var epoch = date1904 ? Epoch1904 : Epoch1900;
+        return epoch.AddDays(serial).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private static string? ConcatText(XElement? container)
+    {
+        if (container == null) return null;
+
+        var builder = new StringBuilder();
+        foreach (var textElem in container.Descendants(SpreadsheetNs + "t"))
+        {
+            builder.Append(textElem.Value);
+        }
+
+        return builder.Length > 0 ? builder.ToString() : null;
+    }
+
+    private static List<string> ReadSharedStrings(ZipArchive archive)
+    {
+        var shared = new List<string>();
+        var entry = archive.GetEntry("xl/sharedStrings.xml");
+        if (entry == null) return shared;
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        if (xDoc.Root == null) return shared;
+
+        foreach (var item in xDoc.Descendants(SpreadsheetNs + "si"))
+        {
+            var text = ConcatText(item);
+            shared.Add(text ?? string.Empty);
+        }
+
+        return shared;
+    }
+
+    private static (List<int> XfNumberFormats, Dictionary<int, string> CustomFormats) ReadNumberFormats(ZipArchive archive)
+    {
+        var xfNumberFormats = new List<int>();
+        var customFormats = new Dictionary<int, string>();
+        var entry = archive.GetEntry("xl/styles.xml");
+        if (entry == null) return (xfNumberFormats, customFormats);
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        if (xDoc.Root == null) return (xfNumberFormats, customFormats);
+
+        foreach (var format in xDoc.Descendants(SpreadsheetNs + "numFmt"))
+        {
+            if (int.TryParse(format.Attribute("numFmtId")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) &&
+                format.Attribute("formatCode")?.Value is { } code)
+            {
+                customFormats[id] = code;
+            }
+        }
+
+        // Cell style indexes reference cellXfs only; cellStyleXfs also contains xf elements
+        // and must be excluded or every index after it would shift.
+        foreach (var xf in xDoc.Descendants(SpreadsheetNs + "cellXfs").Descendants(SpreadsheetNs + "xf"))
+        {
+            xfNumberFormats.Add(
+                int.TryParse(xf.Attribute("numFmtId")?.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) ? id : 0);
+        }
+
+        return (xfNumberFormats, customFormats);
+    }
+
+    private static bool ReadDate1904Flag(ZipArchive archive)
+    {
+        var entry = archive.GetEntry("xl/workbook.xml");
+        if (entry == null) return false;
+
+        using var stream = entry.Open();
+        var xDoc = XDocument.Load(stream);
+        return (string?)xDoc.Root?.Element(SpreadsheetNs + "workbookPr")?.Attribute("date1904") == "1";
     }
 }

--- a/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
+++ b/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Lertaro.PluginSdk.Helpers;
 using Lertaro.Plugins.ContentSearch.Extraction;
 using Lertaro.Plugins.ContentSearch.Storage;
 
@@ -50,6 +51,12 @@ public sealed class ContentIndexScheduler : IDisposable
     public static string NormalizeFolderPath(string rawFolder)
     {
         var folder = Environment.ExpandEnvironmentVariables(rawFolder).Trim();
+        if (string.IsNullOrWhiteSpace(folder)) return string.Empty;
+
+        // Whitelist entries may use Windows shell virtual paths (e.g. "shell:Personal"); these
+        // must be resolved to their physical folder before any filesystem/Path operations,
+        // which would otherwise fail or mangle the "shell:" prefix.
+        folder = ShellPathHelper.TryResolveVirtualPath(folder);
         if (string.IsNullOrWhiteSpace(folder)) return string.Empty;
 
         if (folder.Length == 2 && char.IsLetter(folder[0]) && folder[1] == ':')

--- a/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
+++ b/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
@@ -127,8 +127,10 @@ public sealed class ContentIndexScheduler : IDisposable
 
                 _database.Optimize();
             }
-            catch
+            catch (Exception ex)
             {
+                PluginSdk.Logger.Log(
+                    $"[ContentSearch] Full scan failed: {ex.Message}", PluginSdk.LogLevel.Error);
             }
             finally
             {
@@ -245,8 +247,12 @@ public sealed class ContentIndexScheduler : IDisposable
 
                 writeBatch.Add(new FileIndexBatchItem(filePath, fileInfo.LastWriteTimeUtc, fileInfo.Length, text));
             }
-            catch
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
             {
+                PluginSdk.Logger.Log(
+                    $"[ContentSearch] Failed to index '{filePath}': {ex.Message}",
+                    PluginSdk.LogLevel.Warn);
             }
             finally
             {

--- a/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
+++ b/Plugins/ContentSearch/Indexing/ContentIndexScheduler.cs
@@ -10,7 +10,6 @@ namespace Lertaro.Plugins.ContentSearch.Indexing;
 /// </summary>
 public sealed class ContentIndexScheduler : IDisposable
 {
-    private const int MaxParallelExtractors = 4;
     private const int WriteBatchSize = 50;
 
     private readonly ContentSearchDatabase _database;
@@ -28,6 +27,13 @@ public sealed class ContentIndexScheduler : IDisposable
     public bool IsIndexing => !_pendingFiles.IsEmpty;
     public int PendingCount => _pendingFiles.Count;
 
+    // Extraction is CPU-heavy (PDF/XML parsing). Running all four lanes on a low-core machine
+    // starves the UI thread and thread-pool continuations -- the settings window then takes
+    // seconds to open while indexing. Cap the lanes at half the cores so the UI always keeps
+    // headroom, with 8 as the ceiling for high-core machines.
+    internal static int GetExtractorParallelism(int processorCount) =>
+        Math.Clamp(processorCount - 2, 1, 8);
+
     public ContentIndexScheduler(ContentSearchDatabase database)
     {
         _database = database;
@@ -38,7 +44,22 @@ public sealed class ContentIndexScheduler : IDisposable
     {
         UpdateConfig(config);
         _cts = new CancellationTokenSource();
-        _workerTask = Task.Run(() => WorkerLoopAsync(_cts.Token));
+        _workerTask = Task.Factory.StartNew(
+            () =>
+            {
+                try
+                {
+                    // Dedicated below-normal thread: the scheduler loop and DB writes must
+                    // never win CPU against the UI. LongRunning keeps this thread out of the
+                    // thread pool, so its priority sticks and pool starvation cannot stall it.
+                    Thread.CurrentThread.Priority = ThreadPriority.BelowNormal;
+                    WorkerLoop(_cts.Token);
+                }
+                catch (OperationCanceledException) { }
+            },
+            _cts.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
         TriggerFullScan();
     }
 
@@ -171,7 +192,7 @@ public sealed class ContentIndexScheduler : IDisposable
         return _config.AllowedExtensions.Contains(ext);
     }
 
-    private async Task WorkerLoopAsync(CancellationToken ct)
+    private void WorkerLoop(CancellationToken ct)
     {
         var hasPendingOptimizations = false;
         var idleCycles = 0;
@@ -197,16 +218,18 @@ public sealed class ContentIndexScheduler : IDisposable
                         idleCycles = 0;
                     }
                 }
-                await Task.Delay(200, ct);
+                if (ct.WaitHandle.WaitOne(200)) break;
                 continue;
             }
 
             idleCycles = 0;
             hasPendingOptimizations = true;
 
-            await ProcessBatchAsync(batch, ct);
+            // Blocking wait is fine here: this is the dedicated below-normal scheduler
+            // thread, and the parallel extraction lanes run on thread-pool threads.
+            ProcessBatchAsync(batch, ct).GetAwaiter().GetResult();
             _database.Checkpoint(truncate: false);
-            await Task.Delay(20, ct);
+            if (ct.WaitHandle.WaitOne(20)) break;
         }
     }
 
@@ -215,7 +238,7 @@ public sealed class ContentIndexScheduler : IDisposable
         var writeBatch = new ConcurrentBag<FileIndexBatchItem>();
         var deleteBatch = new ConcurrentBag<string>();
 
-        using var semaphore = new SemaphoreSlim(MaxParallelExtractors);
+        using var semaphore = new SemaphoreSlim(GetExtractorParallelism(Environment.ProcessorCount));
         var tasks = filePaths.Select(async filePath =>
         {
             await semaphore.WaitAsync(ct);

--- a/Plugins/ContentSearch/Indexing/FolderScanDiscoveryHelper.cs
+++ b/Plugins/ContentSearch/Indexing/FolderScanDiscoveryHelper.cs
@@ -3,8 +3,11 @@ using Lertaro.PluginSdk.Services;
 namespace Lertaro.Plugins.ContentSearch.Indexing;
 
 /// <summary>
-/// Scans monitored directories using SDK host index or safe filesystem enumeration to discover modified files.
-/// Split out purely to keep ContentIndexScheduler under the repository per-file line limit.
+/// Scans monitored directories using the SDK host index plus a filesystem walk to discover modified files.
+/// The host index can answer from a stale snapshot (e.g. the service has not yet picked up recently
+/// created files) and a non-empty enumeration carries no completeness signal, so the filesystem walk
+/// always runs as well and the two result sets merge. Split out purely to keep ContentIndexScheduler
+/// under the repository per-file line limit.
 /// </summary>
 public static class FolderScanDiscoveryHelper
 {
@@ -26,7 +29,6 @@ public static class FolderScanDiscoveryHelper
 
             try
             {
-                var enumeratedAny = false;
                 await foreach (var item in DirectoryIndexerService.EnumerateDirectoryAsync(
                     folder,
                     recursive: true,
@@ -34,7 +36,6 @@ public static class FolderScanDiscoveryHelper
                     limit: 0,
                     token: ct).ConfigureAwait(false))
                 {
-                    enumeratedAny = true;
                     if (ct.IsCancellationRequested) return discovered;
                     if (item.IsDir) continue;
 
@@ -60,23 +61,23 @@ public static class FolderScanDiscoveryHelper
 
                     onEnqueue(file);
                 }
-
-                if (!enumeratedAny && Directory.Exists(folder))
-                {
-                    ScanFilesystemFallback(folder, config, existingMeta, discovered, onEnqueue, ct);
-                }
             }
             catch (OperationCanceledException) { return discovered; }
             catch
             {
-                ScanFilesystemFallback(folder, config, existingMeta, discovered, onEnqueue, ct);
+                // Host enumeration unavailable (service down, pipe timeout): the filesystem
+                // walk below still covers the folder, so keep going instead of failing.
             }
+
+            // Runs even when the host enumeration answered: its snapshot may be stale.
+            if (ct.IsCancellationRequested) return discovered;
+            ScanFilesystem(folder, config, existingMeta, discovered, onEnqueue, ct);
         }
 
         return discovered;
     }
 
-    private static void ScanFilesystemFallback(
+    private static void ScanFilesystem(
         string folder,
         ContentIndexConfig config,
         Dictionary<string, (long LastModified, long FileSize)> existingMeta,
@@ -102,7 +103,11 @@ public static class FolderScanDiscoveryHelper
                     if (string.IsNullOrEmpty(ext) || !config.AllowedExtensions.Contains(ext))
                         continue;
 
-                    discovered.Add(file);
+                    // The host enumeration already reported (and possibly enqueued) this file;
+                    // keep the onEnqueue contract at "at most once per file".
+                    if (!discovered.Add(file))
+                        continue;
+
                     try
                     {
                         var info = new FileInfo(file);

--- a/Tests/App/ViewModels/Settings/Plugins/PluginInfoViewModelTests.cs
+++ b/Tests/App/ViewModels/Settings/Plugins/PluginInfoViewModelTests.cs
@@ -265,4 +265,70 @@ public sealed class PluginInfoViewModelTests
         Assert.IsNotNull(vm.FlatConfigFields);
         Assert.HasCount(1, vm.FlatConfigFields);
     }
+
+    [TestMethod]
+    public void IsFullyDisabled_AllToggleableComponentsStartDisabled_True()
+    {
+        var vm = MakeVm(new List<PluginComponentViewModel>
+        {
+            Component("a1", PluginComponentType.Action, enabled: false),
+            Component("f1", PluginComponentType.FilterProvider, enabled: false),
+        });
+
+        Assert.IsTrue(vm.IsFullyDisabled);
+    }
+
+    [TestMethod]
+    public void IsFullyDisabled_SomeComponentStillEnabled_False()
+    {
+        var vm = MakeVm(new List<PluginComponentViewModel>
+        {
+            Component("a1", PluginComponentType.Action, enabled: false),
+            Component("f1", PluginComponentType.FilterProvider, enabled: true),
+        });
+
+        Assert.IsFalse(vm.IsFullyDisabled);
+    }
+
+    [TestMethod]
+    public void IsFullyDisabled_NoToggleableComponents_False()
+    {
+        // Translation/theme-only plugins have nothing the user can turn off, so they can
+        // never count as fully disabled.
+        var vm = MakeVm(new List<PluginComponentViewModel>
+        {
+            Component("t1", PluginComponentType.TranslationProvider, enabled: true),
+        });
+
+        Assert.IsFalse(vm.IsFullyDisabled);
+    }
+
+    [TestMethod]
+    public void IsFullyDisabled_TogglingLastComponentOn_FlipsToFalseAndRaisesEvent()
+    {
+        var a1 = Component("a1", PluginComponentType.Action, enabled: false);
+        var vm = MakeVm(new List<PluginComponentViewModel> { a1 });
+        var raised = new List<PluginInfoViewModel>();
+        vm.FullyDisabledChanged += raised.Add;
+
+        a1.IsEnabled = true;
+
+        Assert.IsFalse(vm.IsFullyDisabled);
+        Assert.HasCount(1, raised);
+        Assert.AreSame(vm, raised[0]);
+    }
+
+    [TestMethod]
+    public void IsFullyDisabled_TogglingLastComponentOff_FlipsToTrueAndRaisesEvent()
+    {
+        var a1 = Component("a1", PluginComponentType.Action, enabled: true);
+        var vm = MakeVm(new List<PluginComponentViewModel> { a1 });
+        var raised = 0;
+        vm.FullyDisabledChanged += _ => raised++;
+
+        a1.IsEnabled = false;
+
+        Assert.IsTrue(vm.IsFullyDisabled);
+        Assert.AreEqual(1, raised);
+    }
 }

--- a/Tests/App/ViewModels/Settings/Plugins/PluginManagementViewModelSortTests.cs
+++ b/Tests/App/ViewModels/Settings/Plugins/PluginManagementViewModelSortTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.ObjectModel;
+using Lertaro.App.Helpers;
+using Lertaro.App.ViewModels.Settings.Plugins;
+
+namespace Lertaro.App.Tests.ViewModels.Settings.Plugins;
+
+[TestClass]
+public sealed class PluginManagementViewModelSortTests
+{
+    private static PluginInfoViewModel MakePlugin(
+        string name,
+        bool fullyDisabled = false,
+        bool hasConfigFields = false,
+        bool hasToggleable = true)
+    {
+        var components = new List<PluginComponentViewModel>();
+        if (hasConfigFields)
+        {
+            var field = new PluginConfigFieldViewModel(
+                name, new PluginSdk.Abstractions.PluginConfigField { Key = "k", FieldType = PluginSdk.Abstractions.ConfigFieldType.Text, DefaultValue = "" },
+                new Core.UserSettings(), () => { });
+            return new PluginInfoViewModel(name, "1.0", name + ".dll", "1.0-sdk", components, [field]);
+        }
+
+        if (hasToggleable)
+        {
+            components.Add(new PluginComponentViewModel(name + "::c", PluginComponentType.Action, name, isEnabled: !fullyDisabled));
+        }
+        else
+        {
+            // Translation/theme-only plugins cannot be disabled and never count as fully disabled.
+            components.Add(new PluginComponentViewModel(name + "::t", PluginComponentType.TranslationProvider, name, isEnabled: true));
+        }
+
+        return new PluginInfoViewModel(name, "1.0", name + ".dll", "1.0-sdk", components, []);
+    }
+
+    [TestMethod]
+    public void SortForDisplay_FullyDisabledPlugins_SinkBelowAllActiveOnes()
+    {
+        var disabledConfigurable = MakePlugin("DisabledConfig", fullyDisabled: true, hasConfigFields: false, hasToggleable: true);
+        var activePlain = MakePlugin("ActivePlain", hasToggleable: true);
+        var readOnly = MakePlugin("ReadOnly", hasToggleable: false);
+        var disabledPlain = MakePlugin("ADisabled", fullyDisabled: true, hasToggleable: true);
+
+        var sorted = PluginLoaderHelper.SortForDisplay(new List<PluginInfoViewModel> { disabledConfigurable, activePlain, readOnly, disabledPlain });
+
+        // Every active plugin precedes every fully-disabled one; rank and name order intact within each.
+        Assert.AreEqual("ActivePlain", sorted[0].Name);
+        Assert.AreEqual("ReadOnly", sorted[1].Name);
+        Assert.AreEqual("ADisabled", sorted[2].Name);
+        Assert.AreEqual("DisabledConfig", sorted[3].Name);
+    }
+
+    [TestMethod]
+    public void SortForDisplay_NoDisabledPlugins_KeepsRankAndNameOrder()
+    {
+        var plain = MakePlugin("BPlain", hasToggleable: true);
+        var configurable = MakePlugin("AConfig", hasConfigFields: true);
+
+        var sorted = PluginLoaderHelper.SortForDisplay(new List<PluginInfoViewModel> { plain, configurable });
+
+        // Configurable plugins are still the most actionable band, alphabetical inside it.
+        Assert.AreEqual("AConfig", sorted[0].Name);
+        Assert.AreEqual("BPlain", sorted[1].Name);
+    }
+
+    [TestMethod]
+    public void MovePluginForDisabledState_LastToggleTurnedOff_MovesIntoSortedDisabledTail()
+    {
+        var active = MakePlugin("Active", hasToggleable: true);
+        var other = MakePlugin("Beta", fullyDisabled: true, hasToggleable: true);
+        var moving = MakePlugin("Moving", hasToggleable: true);
+        var plugins = new ObservableCollection<PluginInfoViewModel> { moving, active, other };
+
+        // Turning the moving plugin's last component off crosses the fully-disabled boundary;
+        // it must land after "Beta" (alphabetical inside the disabled tail), not bluntly last.
+        moving.RawComponents.Single().IsEnabled = false;
+        PluginManagementViewModel.MovePluginForDisabledState(plugins, moving);
+
+        CollectionAssert.AreEquivalent(new[] { "Active", "Beta", "Moving" }, plugins.Select(p => p.Name).ToList());
+        Assert.AreEqual(2, plugins.IndexOf(moving));
+    }
+
+    [TestMethod]
+    public void MovePluginForDisabledState_Reenabled_ReturnsToAlphabeticalActivePosition()
+    {
+        var active = MakePlugin("Active", hasToggleable: true);
+        var disabled = MakePlugin("Zed", fullyDisabled: true, hasToggleable: true);
+        var reenabling = MakePlugin("Mid", fullyDisabled: true, hasToggleable: true);
+        var plugins = new ObservableCollection<PluginInfoViewModel> { active, disabled, reenabling };
+
+        // Reactivating inserts before the first still-disabled plugin ("Zed"), not bluntly last.
+        reenabling.RawComponents.Single().IsEnabled = true;
+        PluginManagementViewModel.MovePluginForDisabledState(plugins, reenabling);
+
+        CollectionAssert.AreEquivalent(new[] { "Active", "Mid", "Zed" }, plugins.Select(p => p.Name).ToList());
+        Assert.AreEqual(1, plugins.IndexOf(reenabling));
+    }
+
+    [TestMethod]
+    public void MovePluginForDisabledState_PluginNotInList_NoOperation()
+    {
+        var plugins = new ObservableCollection<PluginInfoViewModel> { MakePlugin("Active", hasToggleable: true) };
+        var stranger = MakePlugin("Stranger", hasToggleable: true);
+
+        PluginManagementViewModel.MovePluginForDisabledState(plugins, stranger);
+
+        Assert.HasCount(1, plugins);
+    }
+}

--- a/Tests/Plugins/ContentSearch/Extraction/DocxExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/DocxExtractorTests.cs
@@ -26,10 +26,7 @@ public sealed class DocxExtractorTests
         {
             using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
             {
-                var entry = zip.CreateEntry("word/document.xml");
-                using var stream = entry.Open();
-                using var writer = new StreamWriter(stream);
-                writer.Write("""
+                WriteEntry(zip, "word/document.xml", """
                     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
                     <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
                         <w:body>
@@ -51,5 +48,82 @@ public sealed class DocxExtractorTests
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
         }
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_SyntheticDocx_ExtractsHeadersFootersNotesAndComments()
+    {
+        var extractor = new DocxExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_docx_{Guid.NewGuid():N}.docx");
+
+        try
+        {
+            using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
+            {
+                WriteEntry(zip, "word/document.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:body>
+                            <w:p><w:r><w:t>Body text with a</w:t><w:tab/><w:t>tabbed tail.</w:t></w:r></w:p>
+                        </w:body>
+                    </w:document>
+                    """);
+                WriteEntry(zip, "word/header1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:p><w:r><w:t>Header with quarterly numbers.</w:t></w:r></w:p>
+                    </w:hdr>
+                    """);
+                WriteEntry(zip, "word/footer1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:p><w:r><w:t>Footer confidentiality notice.</w:t></w:r></w:p>
+                    </w:ftr>
+                    """);
+                WriteEntry(zip, "word/footnotes.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:footnote w:id="-1"><w:p><w:r><w:t>separator mark</w:t></w:r></w:p></w:footnote>
+                        <w:footnote w:id="0"><w:p><w:r><w:t>continuation mark</w:t></w:r></w:p></w:footnote>
+                        <w:footnote w:id="1"><w:p><w:r><w:t>Footnote explains the term.</w:t></w:r></w:p></w:footnote>
+                    </w:footnotes>
+                    """);
+                WriteEntry(zip, "word/comments.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                        <w:comment w:id="1" w:author="Reviewer A">
+                            <w:p><w:r><w:t>Please rewrite this sentence.</w:t></w:r></w:p>
+                        </w:comment>
+                    </w:comments>
+                    """);
+            }
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.Contains("Body text with a", text);
+            Assert.Contains("tabbed tail.", text);
+            Assert.Contains("Header with quarterly numbers.", text);
+            Assert.Contains("Footer confidentiality notice.", text);
+            // Real note content is indexed; separator/continuation marks (ids -1 and 0) are not.
+            Assert.Contains("Footnote explains the term.", text);
+            Assert.DoesNotContain("separator mark", text);
+            Assert.DoesNotContain("continuation mark", text);
+            Assert.Contains("Reviewer A", text);
+            Assert.Contains("Please rewrite this sentence.", text);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static void WriteEntry(ZipArchive zip, string name, string content)
+    {
+        var entry = zip.CreateEntry(name);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
     }
 }

--- a/Tests/Plugins/ContentSearch/Extraction/PdfExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/PdfExtractorTests.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using Lertaro.Plugins.ContentSearch.Extraction;
+
+namespace Lertaro.Plugins.ContentSearch.Tests.Extraction;
+
+[TestClass]
+public sealed class PdfExtractorTests
+{
+    [TestMethod]
+    public void CanHandle_PdfExtension_Only()
+    {
+        var extractor = new PdfExtractor();
+        Assert.IsTrue(extractor.CanHandle(".pdf"));
+        Assert.IsFalse(extractor.CanHandle(".txt"));
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_PlainTwoPageDocument_ReturnsAllPages()
+    {
+        var extractor = new PdfExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_doc_{Guid.NewGuid():N}.pdf");
+
+        try
+        {
+            await File.WriteAllBytesAsync(tempFile, BuildTwoPagePdf(TextStream("first page words"), TextStream("second page words")));
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.IsTrue(text.Contains("first page words"));
+            Assert.IsTrue(text.Contains("second page words"));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_PageWithSlightlyRotatedGlyphs_SkipsBadPageExtractsRest()
+    {
+        // Regression: PdfPig 0.1.9 throws "Could not find TextOrientation for rotation" for
+        // glyphs with zero advance width on a ~4 degree rotated text matrix, which previously
+        // made the extractor discard the whole document (real case: a PDF whose page 4 has
+        // such glyphs was entirely unindexable).
+        var extractor = new PdfExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_doc_{Guid.NewGuid():N}.pdf");
+
+        try
+        {
+            // Zero horizontal scale collapses glyph advances; the precise 4 degree matrix then
+            // reaches Letter.GetTextOrientationRot with a rotation near an integer that is not
+            // a multiple of 90, which throws in PdfPig 0.1.9.
+            const string rotatedPage =
+                "BT 0.99756405 0.06975647 -0.06975647 0.99756405 72 720 Tm /F1 12 Tf 0 Tz (Rotated page) Tj ET";
+            await File.WriteAllBytesAsync(tempFile, BuildTwoPagePdf(TextStream("Cysteine normal page"), rotatedPage));
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.IsTrue(text.Contains("Cysteine normal page"));
+            Assert.IsFalse(text.Contains("Rotated page"));
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static string TextStream(string text) => $"BT /F1 12 Tf 72 720 Td ({text}) Tj ET";
+
+    private static byte[] BuildTwoPagePdf(string firstPageContentStream, string secondPageContentStream)
+    {
+        var objects = new List<string>
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 6 0 R >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 5 0 R >> >> /Contents 7 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        };
+
+        objects.Add($"<< /Length {firstPageContentStream.Length} >>\nstream\n{firstPageContentStream}\nendstream");
+        objects.Add($"<< /Length {secondPageContentStream.Length} >>\nstream\n{secondPageContentStream}\nendstream");
+
+        var sb = new StringBuilder();
+        sb.Append("%PDF-1.4\n");
+        var offsets = new List<int>();
+        foreach (var (obj, idx) in objects.Select((o, i) => (o, i)))
+        {
+            offsets.Add(sb.Length);
+            sb.Append($"{idx + 1} 0 obj\n{obj}\nendobj\n");
+        }
+
+        var xrefStart = sb.Length;
+        sb.Append($"xref\n0 {objects.Count + 1}\n0000000000 65535 f \n");
+        foreach (var offset in offsets)
+            sb.Append($"{offset:D10} 00000 n \n");
+        sb.Append($"trailer\n<< /Size {objects.Count + 1} /Root 1 0 R >>\nstartxref\n{xrefStart}\n%%EOF\n");
+
+        return Encoding.Latin1.GetBytes(sb.ToString());
+    }
+}

--- a/Tests/Plugins/ContentSearch/Extraction/PdfExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/PdfExtractorTests.cs
@@ -26,8 +26,8 @@ public sealed class PdfExtractorTests
             var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
 
             Assert.IsNotNull(text);
-            Assert.IsTrue(text.Contains("first page words"));
-            Assert.IsTrue(text.Contains("second page words"));
+            Assert.Contains("first page words", text);
+            Assert.Contains("second page words", text);
         }
         finally
         {
@@ -58,8 +58,8 @@ public sealed class PdfExtractorTests
             var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
 
             Assert.IsNotNull(text);
-            Assert.IsTrue(text.Contains("Cysteine normal page"));
-            Assert.IsFalse(text.Contains("Rotated page"));
+            Assert.Contains("Cysteine normal page", text);
+            Assert.DoesNotContain("Rotated page", text);
         }
         finally
         {

--- a/Tests/Plugins/ContentSearch/Extraction/PlainTextExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/PlainTextExtractorTests.cs
@@ -3,9 +3,24 @@ using Lertaro.Plugins.ContentSearch.Extraction;
 
 namespace Lertaro.Plugins.ContentSearch.Tests.Extraction;
 
+// PlainTextExtractor tests share the process-wide PluginSdk.Logger.LogAction hook,
+// so they must not run concurrently with anything that reads or resets it.
 [TestClass]
+[DoNotParallelize]
 public sealed class PlainTextExtractorTests
 {
+    private readonly List<string> _logLines = new();
+
+    [TestInitialize]
+    public void CaptureLogs()
+    {
+        _logLines.Clear();
+        PluginSdk.Logger.LogAction = (message, level) => _logLines.Add($"{level}: {message}");
+    }
+
+    [TestCleanup]
+    public void ReleaseLogs() => PluginSdk.Logger.LogAction = null;
+
     [TestMethod]
     public void CanHandle_AnyNonEmptyExtension_ReturnsTrue()
     {
@@ -126,5 +141,49 @@ public sealed class PlainTextExtractorTests
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
         }
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_BinaryFileWithoutExtractor_SkipsAndLogsWarning()
+    {
+        var extractor = new PlainTextExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_doc_{Guid.NewGuid():N}.doc");
+
+        try
+        {
+            // OLE compound file signature bytes as written by legacy .doc/.xls/.ppt, followed
+            // by the NUL-padded directory sector: typing "doc" into the whitelist lands here.
+            var oleBytes = new byte[512];
+            oleBytes[0] = 0xD0; oleBytes[1] = 0xCF; oleBytes[2] = 0x11; oleBytes[3] = 0xE0;
+            oleBytes[4] = 0xA1; oleBytes[5] = 0xB1; oleBytes[6] = 0x1A; oleBytes[7] = 0xE1;
+            await File.WriteAllBytesAsync(tempFile, oleBytes);
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNull(text);
+            Assert.IsTrue(
+                _logLines.Any(l => l.Contains("Skipped binary file", StringComparison.Ordinal) && l.Contains(tempFile, StringComparison.Ordinal)),
+                $"Expected a skip warning in: [{string.Join("; ", _logLines)}]");
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [TestMethod]
+    public void LooksBinary_NulByteInLeadingChunk_TellsBinaryFromText()
+    {
+        var oleBytes = new byte[256];
+        oleBytes[0] = 0xD0; oleBytes[1] = 0xCF; oleBytes[2] = 0x11; oleBytes[3] = 0xE0;
+        Assert.IsTrue(PlainTextExtractor.LooksBinary(oleBytes));
+        Assert.IsFalse(PlainTextExtractor.LooksBinary(Encoding.UTF8.GetBytes("plain text file\r\n")));
+
+        // UTF-16 text interleaves NUL bytes but carries a BOM: callers must exempt it
+        // via HasUnicodeBom before trusting LooksBinary.
+        var utf16Bytes = new byte[] { 0xFF, 0xFE, 0x2D, 0x00, 0x4E, 0x00 };
+        Assert.IsTrue(PlainTextExtractor.LooksBinary(utf16Bytes));
+        Assert.IsTrue(PlainTextExtractor.HasUnicodeBom(utf16Bytes));
     }
 }

--- a/Tests/Plugins/ContentSearch/Extraction/PlainTextExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/PlainTextExtractorTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Lertaro.Plugins.ContentSearch.Extraction;
 
 namespace Lertaro.Plugins.ContentSearch.Tests.Extraction;
@@ -50,6 +51,75 @@ public sealed class PlainTextExtractorTests
             var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 5); // 5 bytes limit
 
             Assert.IsNull(text);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [TestMethod]
+    public void DecodeText_GbkBytesWithoutBom_DecodesChinese()
+    {
+        // "这是文本文档" in GBK: D5E2 CAC7 CEC4 B1BE CEC4 B5B5; these bytes are invalid UTF-8.
+        var gbkBytes = new byte[]
+        {
+            0xD5, 0xE2, 0xCA, 0xC7, 0xCE, 0xC4, 0xB1, 0xBE, 0xCE, 0xC4, 0xB5, 0xB5
+        };
+
+        Assert.AreEqual("这是文本文档", PlainTextExtractor.DecodeText(gbkBytes));
+    }
+
+    [TestMethod]
+    public void DecodeText_Utf16LeBom_DecodesChinese()
+    {
+        // BOM FF FE followed by "中文ok" in UTF-16 LE.
+        var utf16Bytes = new byte[]
+        {
+            0xFF, 0xFE, 0x2D, 0x4E, 0x87, 0x65, 0x6F, 0x00, 0x6B, 0x00
+        };
+
+        Assert.AreEqual("中文ok", PlainTextExtractor.DecodeText(utf16Bytes));
+    }
+
+    [TestMethod]
+    public void DecodeText_Utf8Bom_DecodesWithoutBomArtifact()
+    {
+        var utf8BomBytes = new byte[] { 0xEF, 0xBB, 0xBF }
+            .Concat(Encoding.UTF8.GetBytes("价格bom"))
+            .ToArray();
+
+        Assert.AreEqual("价格bom", PlainTextExtractor.DecodeText(utf8BomBytes));
+    }
+
+    [TestMethod]
+    public void DecodeText_Utf8WithoutBom_Unchanged()
+    {
+        var utf8Bytes = Encoding.UTF8.GetBytes("plain ascii with 中文");
+
+        Assert.AreEqual("plain ascii with 中文", PlainTextExtractor.DecodeText(utf8Bytes));
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_GbkEncodedFile_ExtractsReadableChinese()
+    {
+        var extractor = new PlainTextExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_doc_{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            // "这是文本文档" in GBK plus a CRLF, mirroring a legacy Windows notepad file.
+            var gbkBytes = new byte[]
+            {
+                0xD5, 0xE2, 0xCA, 0xC7, 0xCE, 0xC4, 0xB1, 0xBE, 0xCE, 0xC4, 0xB5, 0xB5, 0x0D, 0x0A
+            };
+            await File.WriteAllBytesAsync(tempFile, gbkBytes);
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.AreEqual("这是文本文档", text.Trim());
         }
         finally
         {

--- a/Tests/Plugins/ContentSearch/Extraction/PptxExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/PptxExtractorTests.cs
@@ -27,10 +27,7 @@ public sealed class PptxExtractorTests
         {
             using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
             {
-                var entry = zip.CreateEntry("ppt/slides/slide1.xml");
-                using var stream = entry.Open();
-                using var writer = new StreamWriter(stream);
-                writer.Write("""
+                WriteEntry(zip, "ppt/slides/slide1.xml", """
                     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
                     <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
                            xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
@@ -59,5 +56,73 @@ public sealed class PptxExtractorTests
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
         }
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_SyntheticPptx_ExtractsNotesAndSkipsSlideNumberFields()
+    {
+        var extractor = new PptxExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_pptx_{Guid.NewGuid():N}.pptx");
+
+        try
+        {
+            using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
+            {
+                WriteEntry(zip, "ppt/slides/slide1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                           xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                        <p:cSld>
+                            <p:spTree>
+                                <p:sp>
+                                    <p:txBody>
+                                        <a:p><a:r><a:t>Slide Title Here</a:t></a:r></a:p>
+                                        <a:p><a:r><a:t>Slide bullet point text.</a:t></a:r></a:p>
+                                    </p:txBody>
+                                </p:sp>
+                            </p:spTree>
+                        </p:cSld>
+                    </p:sld>
+                    """);
+                WriteEntry(zip, "ppt/notesSlides/notesSlide1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <p:notes xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                             xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+                        <p:cSld>
+                            <p:spTree>
+                                <p:sp>
+                                    <p:txBody>
+                                        <a:p><a:r><a:t>Speaker note with extra detail.</a:t></a:r></a:p>
+                                        <a:p><a:fld id="{GUID}" type="slidenum"><a:t>7</a:t></a:fld></a:p>
+                                    </p:txBody>
+                                </p:sp>
+                            </p:spTree>
+                        </p:cSld>
+                    </p:notes>
+                    """);
+            }
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.Contains("Slide Title Here", text);
+            Assert.Contains("Slide bullet point text.", text);
+            // Notes are indexed; the repeated slide-number field is skipped.
+            Assert.Contains("Speaker note with extra detail.", text);
+            Assert.DoesNotContain("\n7\n", text);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static void WriteEntry(ZipArchive zip, string name, string content)
+    {
+        var entry = zip.CreateEntry(name);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
     }
 }

--- a/Tests/Plugins/ContentSearch/Extraction/XlsxExtractorTests.cs
+++ b/Tests/Plugins/ContentSearch/Extraction/XlsxExtractorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO.Compression;
 using Lertaro.Plugins.ContentSearch.Extraction;
 
@@ -27,15 +28,20 @@ public sealed class XlsxExtractorTests
         {
             using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
             {
-                var entry = zip.CreateEntry("xl/sharedStrings.xml");
-                using var stream = entry.Open();
-                using var writer = new StreamWriter(stream);
-                writer.Write("""
+                WriteEntry(zip, "xl/sharedStrings.xml", """
                     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
                     <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2" uniqueCount="2">
                         <si><t>Revenue 2026</t></si>
                         <si><t>Projected Growth</t></si>
                     </sst>
+                    """);
+                WriteEntry(zip, "xl/worksheets/sheet1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                        <sheetData>
+                            <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c></row>
+                        </sheetData>
+                    </worksheet>
                     """);
             }
 
@@ -50,5 +56,100 @@ public sealed class XlsxExtractorTests
             if (File.Exists(tempFile))
                 File.Delete(tempFile);
         }
+    }
+
+    [TestMethod]
+    public async Task ExtractTextAsync_SyntheticXlsx_ExtractsNumbersDatesAndInlineStrings()
+    {
+        var extractor = new XlsxExtractor();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_xlsx_{Guid.NewGuid():N}.xlsx");
+
+        try
+        {
+            using (var zip = ZipFile.Open(tempFile, ZipArchiveMode.Create))
+            {
+                WriteEntry(zip, "xl/sharedStrings.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1">
+                        <si><t>Revenue 2026</t></si>
+                    </sst>
+                    """);
+                // cellStyleXfs holds one xf that must not shift the cellXfs indexes used by cell s attributes.
+                WriteEntry(zip, "xl/styles.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                        <cellStyleXfs count="1"><xf numFmtId="0"/></cellStyleXfs>
+                        <cellXfs count="3">
+                            <xf numFmtId="14"/>
+                            <xf numFmtId="0"/>
+                            <xf numFmtId="0"/>
+                        </cellXfs>
+                    </styleSheet>
+                    """);
+                WriteEntry(zip, "xl/worksheets/sheet1.xml", """
+                    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                    <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                        <sheetData>
+                            <row r="1"><c r="A1" t="s"><v>0</v></c></row>
+                            <row r="2"><c r="A2"><v>12345.6</v></c></row>
+                            <row r="3"><c r="A3" s="0"><v>45123</v></c></row>
+                            <row r="4"><c r="A4" s="1"><v>99</v></c></row>
+                            <row r="5"><c r="A5" t="inlineStr"><is><t>Note inline</t></is></c></row>
+                            <row r="6"><c r="A6" t="b"><v>1</v></c></row>
+                        </sheetData>
+                    </worksheet>
+                    """);
+            }
+
+            var text = await extractor.ExtractTextAsync(tempFile, maxFileSizeBytes: 1024 * 1024);
+
+            Assert.IsNotNull(text);
+            Assert.Contains("Revenue 2026", text);
+            Assert.Contains("12345.6", text);
+            // Date-styled cell (numFmtId 14) is normalized to ISO; non-date number stays numeric.
+            var expectedDate = new DateTime(1899, 12, 30).AddDays(45123).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            Assert.Contains(expectedDate, text);
+            // The date-styled cell must not surface as its raw serial number.
+            Assert.DoesNotContain("45123", text);
+            Assert.Contains("99", text);
+            Assert.Contains("Note inline", text);
+            Assert.Contains("TRUE", text);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    [TestMethod]
+    public void IsDateFormat_BuiltInAndCustomCodes()
+    {
+        var custom = new Dictionary<int, string> { { 164, "yyyy\\-mm\\-dd" }, { 165, "0.00" } };
+
+        Assert.IsTrue(XlsxExtractor.IsDateFormat(14, custom));
+        Assert.IsTrue(XlsxExtractor.IsDateFormat(22, custom));
+        Assert.IsTrue(XlsxExtractor.IsDateFormat(164, custom));
+        Assert.IsFalse(XlsxExtractor.IsDateFormat(0, custom));
+        Assert.IsFalse(XlsxExtractor.IsDateFormat(165, custom));
+        Assert.IsFalse(XlsxExtractor.IsDateFormat(999, custom));
+    }
+
+    [TestMethod]
+    public void SerialToIsoDate_RespectsDateSystem()
+    {
+        // Serial 44927 is 2023-01-01 in the default 1900 date system.
+        Assert.AreEqual("2023-01-01", XlsxExtractor.SerialToIsoDate(44927, date1904: false));
+        // The 1904 system drops the two fictional 1900 leap-day serials, so the same
+        // calendar date sits 1462 serials earlier.
+        Assert.AreEqual("2023-01-01", XlsxExtractor.SerialToIsoDate(43465, date1904: true));
+    }
+
+    private static void WriteEntry(ZipArchive zip, string name, string content)
+    {
+        var entry = zip.CreateEntry(name);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream);
+        writer.Write(content);
     }
 }

--- a/Tests/Plugins/ContentSearch/Indexing/ContentIndexSchedulerTests.cs
+++ b/Tests/Plugins/ContentSearch/Indexing/ContentIndexSchedulerTests.cs
@@ -90,6 +90,19 @@ public sealed class ContentIndexSchedulerTests
     }
 
     [TestMethod]
+    public void GetExtractorParallelism_ScalesWithCoresAndCapsAtFour()
+    {
+        // Half the cores, minimum one lane so indexing still progresses on 1-2 core machines,
+        // capped at four so high-core machines do not over-parallelize the CPU-bound parsing.
+        Assert.AreEqual(1, ContentIndexScheduler.GetExtractorParallelism(1));
+        Assert.AreEqual(1, ContentIndexScheduler.GetExtractorParallelism(2));
+        Assert.AreEqual(2, ContentIndexScheduler.GetExtractorParallelism(4));
+        Assert.AreEqual(3, ContentIndexScheduler.GetExtractorParallelism(6));
+        Assert.AreEqual(4, ContentIndexScheduler.GetExtractorParallelism(8));
+        Assert.AreEqual(4, ContentIndexScheduler.GetExtractorParallelism(32));
+    }
+
+    [TestMethod]
     public void TriggerFullScan_DisallowedExtensions_PrunedFromDatabaseImmediately()
     {
         _database.InsertOrUpdateFile(@"C:\MyDocs\doc1.pdf", DateTime.UtcNow, 1024, "PDF text");

--- a/Tests/Plugins/ContentSearch/Indexing/ContentIndexSchedulerTests.cs
+++ b/Tests/Plugins/ContentSearch/Indexing/ContentIndexSchedulerTests.cs
@@ -62,6 +62,34 @@ public sealed class ContentIndexSchedulerTests
     }
 
     [TestMethod]
+    public void NormalizeFolderPath_ShellVirtualPath_ResolvesToPhysicalFolder()
+    {
+        var resolved = ContentIndexScheduler.NormalizeFolderPath("shell:Personal");
+
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        Assert.IsFalse(string.IsNullOrEmpty(documents));
+        Assert.AreEqual(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(documents)),
+            resolved,
+            ignoreCase: true);
+    }
+
+    [TestMethod]
+    public void IsFileInMonitoredFolders_ShellVirtualPathEntry_MatchesPhysicalFiles()
+    {
+        using var scheduler = new ContentIndexScheduler(_database);
+        var config = new ContentIndexConfig
+        {
+            MonitoredFolders = new List<string> { "shell:Personal" }
+        };
+        scheduler.UpdateConfig(config);
+
+        var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        Assert.IsTrue(scheduler.IsFileInMonitoredFolders(Path.Combine(documents, "note.txt")));
+        Assert.IsFalse(scheduler.IsFileInMonitoredFolders(@"C:\OtherFolder\file.txt"));
+    }
+
+    [TestMethod]
     public void TriggerFullScan_DisallowedExtensions_PrunedFromDatabaseImmediately()
     {
         _database.InsertOrUpdateFile(@"C:\MyDocs\doc1.pdf", DateTime.UtcNow, 1024, "PDF text");

--- a/Tests/Plugins/ContentSearch/Indexing/FolderScanDiscoveryHelperTests.cs
+++ b/Tests/Plugins/ContentSearch/Indexing/FolderScanDiscoveryHelperTests.cs
@@ -1,10 +1,18 @@
+using Lertaro.PluginSdk.Abstractions;
+using Lertaro.PluginSdk.Services;
 using Lertaro.Plugins.ContentSearch.Indexing;
 
 namespace Lertaro.Plugins.ContentSearch.Tests.Indexing;
 
+// The host enumeration hook (DirectoryIndexerService.EnumerateDirectoryFunc) is process-wide
+// static state, so these tests must not run concurrently with anything that reads or resets it.
 [TestClass]
+[DoNotParallelize]
 public sealed class FolderScanDiscoveryHelperTests
 {
+    [TestCleanup]
+    public void ResetHostEnumeration() => DirectoryIndexerService.EnumerateDirectoryFunc = null;
+
     [TestMethod]
     public async Task DiscoverFilesAsync_EmptyFolders_ReturnsEmpty()
     {
@@ -23,5 +31,145 @@ public sealed class FolderScanDiscoveryHelperTests
 
         Assert.IsEmpty(discovered);
         Assert.IsEmpty(enqueued);
+    }
+
+    [TestMethod]
+    public async Task DiscoverFilesAsync_StaleHostSnapshot_MergesFilesystemWalk()
+    {
+        // Regression: the service index can answer from a stale snapshot that misses recently
+        // created files; a non-empty answer must not stop the filesystem walk from finding them.
+        var dir = CreateTempDirectory();
+
+        try
+        {
+            foreach (var name in new[] { "a.txt", "b.txt", "c.txt" })
+                await File.WriteAllTextAsync(Path.Combine(dir, name), "content of " + name);
+
+            var hostFiles = new[] { "a.txt" }; // stale snapshot: only one of three files
+            DirectoryIndexerService.EnumerateDirectoryFunc = (folder, recursive, pattern, limit, token) =>
+                EnumerateFake(Path.Combine(dir, hostFiles[0]), (long)new FileInfo(Path.Combine(dir, hostFiles[0])).Length, DateTime.Now);
+
+            var config = new ContentIndexConfig
+            {
+                MonitoredFolders = new List<string> { dir },
+                AllowedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".txt" }
+            };
+            var enqueued = new List<string>();
+
+            var discovered = await FolderScanDiscoveryHelper.DiscoverFilesAsync(
+                config,
+                new Dictionary<string, (long LastModified, long FileSize)>(),
+                enqueued.Add,
+                CancellationToken.None);
+
+            var expected = new[] { "a.txt", "b.txt", "c.txt" }.Select(n => Path.Combine(dir, n)).ToList();
+            CollectionAssert.AreEquivalent(expected, discovered.ToList());
+            Assert.HasCount(3, enqueued);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [TestMethod]
+    public async Task DiscoverFilesAsync_HostEnumerationThrows_StillDiscoversFromDisk()
+    {
+        var dir = CreateTempDirectory();
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(dir, "only.txt"), "content");
+
+            DirectoryIndexerService.EnumerateDirectoryFunc = (_, _, _, _, _) => throw new IOException("service unreachable");
+
+            var config = new ContentIndexConfig
+            {
+                MonitoredFolders = new List<string> { dir },
+                AllowedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".txt" }
+            };
+            var enqueued = new List<string>();
+
+            var discovered = await FolderScanDiscoveryHelper.DiscoverFilesAsync(
+                config,
+                new Dictionary<string, (long LastModified, long FileSize)>(),
+                enqueued.Add,
+                CancellationToken.None);
+
+            CollectionAssert.AreEquivalent(new[] { Path.Combine(dir, "only.txt") }, discovered.ToList());
+            Assert.HasCount(1, enqueued);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [TestMethod]
+    public async Task DiscoverFilesAsync_UnchangedFilesInHostIndex_AreDiscoveredButNotEnqueued()
+    {
+        var dir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(dir, "known.txt");
+            await File.WriteAllTextAsync(filePath, "content");
+
+            DirectoryIndexerService.EnumerateDirectoryFunc = (folder, recursive, pattern, limit, token) =>
+                EnumerateFake(filePath, new FileInfo(filePath).Length, FileInfoMetaModified(filePath));
+
+            var config = new ContentIndexConfig
+            {
+                MonitoredFolders = new List<string> { dir },
+                AllowedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".txt" }
+            };
+            var info = new FileInfo(filePath);
+            var existingMeta = new Dictionary<string, (long LastModified, long FileSize)>
+            {
+                [filePath] = (new DateTimeOffset(info.LastWriteTimeUtc).ToUnixTimeSeconds(), info.Length)
+            };
+            var enqueued = new List<string>();
+
+            var discovered = await FolderScanDiscoveryHelper.DiscoverFilesAsync(
+                config,
+                existingMeta,
+                enqueued.Add,
+                CancellationToken.None);
+
+            CollectionAssert.AreEquivalent(new[] { filePath }, discovered.ToList());
+            Assert.IsEmpty(enqueued);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"scan_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static DateTime FileInfoMetaModified(string filePath) =>
+        // FileMetadata.Modified is local time; mirror the metadata the host would report.
+        new FileInfo(filePath).LastWriteTime;
+
+    private static async IAsyncEnumerable<ISearchResult> EnumerateFake(
+        string fullPath, long size, DateTime modified)
+    {
+        await Task.CompletedTask;
+        yield return new FakeSearchResult(fullPath, size, modified);
+    }
+
+    private sealed class FakeSearchResult(string fullPath, long size, DateTime modified) : ISearchResult
+    {
+        public string Name => Path.GetFileName(fullPath);
+        public string FullPath => fullPath;
+        public string ContextDirectory => Path.GetDirectoryName(fullPath) ?? string.Empty;
+        public bool IsDir => false;
+        public bool IsApplication => false;
+        public FileMetadata Metadata => new(size, modified, modified, modified);
     }
 }


### PR DESCRIPTION
- 白名单支持 shell 虚拟路径（如 shell:Personal）
- 支持 GBK/GB2312 编码的文本文件
- xlsx 可检索数值与日期单元格（日期规范化为 yyyy-MM-dd）
- docx 可检索页眉、页脚、脚注、尾注、批注；pptx 可检索演讲者备注
- 默认索引扩展名补入 docm/pptm/xlsm
具体实现的思路抄了 dnGREP 的
<!--xx-->
- PDF 单页损坏（如旋转字形异常）不再导致整本书无法索引，只跳过坏页
- 二进制文件（.doc/.exe 等误入白名单）自动跳过，不再乱码入库
- Service 的文件索引快照过时时不再漏掉新建文件（扫描始终合并文件系统遍历）
<!--xx-->
- 提取失败、二进制跳过、扫描错误均写入 app.log（此前完全静默）
- 低配电脑索引时 UI 不再卡顿：提取并行度按核数自适应（核数-2，1<=x<=8），后台线程降为低优先级

---

- 插件管理页：已被完全禁用的插件自动排到列表末尾，重新启用后立即回到原排序位置

---

话说索引慢和卡我还没排查明白原因，只能先提高UI加载优先级、限制索引的资源占用来抑制此问题……问题是这样又会导致索引速度减慢（不过几百个文件还是轻轻松松的），等啥时候其他人再反馈，你再`@`我就是了

