### PR TITLE
fix: release the Border RoundedClip watched when its window closes

### DIFF
--- a/App/Helpers/Visuals/RoundedClip.cs
+++ b/App/Helpers/Visuals/RoundedClip.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -24,17 +25,81 @@ public static class RoundedClip
     public static void SetIsEnabled(Border border, bool value) => border.SetValue(IsEnabledProperty, value);
     public static bool GetIsEnabled(Border border) => (bool)border.GetValue(IsEnabledProperty);
 
+    // Per-border subscription, keyed weakly: the value closes over the border (through Update), so a
+    // strongly-keyed table here would root every border it had ever seen.
+    private static readonly ConditionalWeakTable<Border, Subscription> Subscriptions = new();
+
+    private sealed record Subscription(DependencyPropertyDescriptor Descriptor, EventHandler Handler, Action Update);
+
     private static void OnIsEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is not Border border || e.NewValue is not true) return;
+        if (d is not Border border) return;
 
-        border.SizeChanged += (_, _) => Update(border);
-        DependencyPropertyDescriptor.FromProperty(Border.CornerRadiusProperty, typeof(Border))
-            .AddValueChanged(border, (_, _) => Update(border));
-        Update(border);
+        border.Loaded -= OnLoaded;
+        border.Unloaded -= OnUnloaded;
+
+        if (e.NewValue is true)
+        {
+            border.Loaded += OnLoaded;
+            border.Unloaded += OnUnloaded;
+            if (border.IsLoaded)
+                Attach(border);
+        }
+        else
+        {
+            Detach(border);
+        }
     }
 
-    private static void Update(Border border) => border.Clip = BuildGeometry(border.RenderSize, border.CornerRadius);
+    private static void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is Border border)
+            Attach(border);
+    }
+
+    private static void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is Border border)
+            Detach(border);
+    }
+
+    private static void Attach(Border border)
+    {
+        Detach(border);
+
+        void Update() => border.Clip = BuildGeometry(border.RenderSize, border.CornerRadius);
+        EventHandler handler = (_, _) => Update();
+
+        // AddValueChanged registers this Border in a PROCESS-WIDE static table
+        // (Type._attachedPropertyBrowsableType). RemoveValueChanged is the only thing that takes it back
+        // out again, so leaving it registered roots the Border -- and through it the whole window visual
+        // tree -- until the process exits. That is exactly what happened here: every closed inline window
+        // stayed alive (measured 17 of them, with a weak-event table grown to 21MB), and each one made
+        // every later UI-thread event dispatch a little slower. Hence the detach on Unloaded below.
+        var descriptor = DependencyPropertyDescriptor.FromProperty(Border.CornerRadiusProperty, typeof(Border));
+        descriptor.AddValueChanged(border, handler);
+
+        Subscriptions.AddOrUpdate(border, new Subscription(descriptor, handler, Update));
+        border.SizeChanged += OnSizeChanged;
+        Update();
+    }
+
+    private static void Detach(Border border)
+    {
+        border.SizeChanged -= OnSizeChanged;
+
+        if (Subscriptions.TryGetValue(border, out var subscription))
+        {
+            subscription.Descriptor.RemoveValueChanged(border, subscription.Handler);
+            Subscriptions.Remove(border);
+        }
+    }
+
+    private static void OnSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (sender is Border border && Subscriptions.TryGetValue(border, out var subscription))
+            subscription.Update();
+    }
 
     private static Geometry BuildGeometry(Size size, CornerRadius r)
     {

--- a/Tests/App/Helpers/Visuals/RoundedClipTests.cs
+++ b/Tests/App/Helpers/Visuals/RoundedClipTests.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Lertaro.App.Helpers.Visuals;
+
+namespace Lertaro.App.Tests.Helpers.Visuals;
+
+// RoundedClip must release the Border it watched when the window closes.
+//
+// The bug this guards against is invisible in any value the code returns: RoundedClip tracked
+// CornerRadius with DependencyPropertyDescriptor.AddValueChanged, which registers the Border in a
+// PROCESS-WIDE static table. RemoveValueChanged is the only thing that takes it back out, and it was
+// never called -- so every closed window stayed reachable (measured: 17 live InlineSearchWindow
+// instances, a weak-event table grown to 21MB, and every later UI-thread event dispatch slower than the
+// last). That is the "settings > Plugins gets laggy after a while, and a restart fixes it" report.
+//
+// [DoNotParallelize] because this shows and closes real windows on its own dispatcher thread, which is
+// process-wide.
+[TestClass]
+[DoNotParallelize]
+public sealed class RoundedClipTests
+{
+    [StaTestMethod]
+    public void AClosedWindowsBorder_BecomesCollectable()
+    {
+        var (borderRef, windowRef) = ShowAndCloseWindowWithRoundedClip();
+
+        Assert.IsFalse(IsAliveAfterFullCollection(borderRef),
+            "the Border must not stay pinned by RoundedClip's value-changed registration after the window closes");
+        Assert.IsFalse(IsAliveAfterFullCollection(windowRef),
+            "and the window it belonged to must be collectable with it");
+    }
+
+    [StaTestMethod]
+    public void DetachingIsWhatMakesItCollectable()
+    {
+        // Same shape, but keeping the AddValueChanged registration alive for the Border's lifetime (no
+        // detach). If this ever stops pinning, the test above would pass for the wrong reason and stop
+        // guarding anything.
+        var (borderRef, windowRef) = ShowAndCloseWindowWithDetach(detach: false);
+
+        Assert.IsTrue(IsAliveAfterFullCollection(borderRef) || IsAliveAfterFullCollection(windowRef),
+            "without the detach, the value-changed registration should still pin the window -- "
+            + "this proves the test above is measuring the fix and not just GC timing");
+    }
+
+    private static (WeakReference Border, WeakReference Window) ShowAndCloseWindowWithRoundedClip() =>
+        ShowAndCloseWindowWithDetach(detach: true);
+
+    private static (WeakReference Border, WeakReference Window) ShowAndCloseWindowWithDetach(bool detach)
+    {
+        WeakReference? borderRef = null;
+        WeakReference? windowRef = null;
+        Exception? failure = null;
+
+        // Its own thread and Dispatcher: Window.Show()/Close() need one, and MSTest's default thread
+        // would leave this test's window registered against a dispatcher other tests also use.
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var window = new Window { Width = 200, Height = 120 };
+                var border = new Border { CornerRadius = new CornerRadius(6) };
+                window.Content = border;
+                RoundedClip.SetIsEnabled(border, true);
+
+                if (!detach)
+                {
+                    // Reproduce the old behaviour: a registration that outlives the Border.
+                    var descriptor = DependencyPropertyDescriptor.FromProperty(Border.CornerRadiusProperty, typeof(Border));
+                    descriptor.AddValueChanged(border, (_, _) => { });
+                }
+
+                window.Show();
+                window.Close();
+
+                // Drain anything the dispatcher queued for the close (Unloaded lands here).
+                Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.ApplicationIdle);
+                window.Dispatcher.Invoke(() => { }, DispatcherPriority.ApplicationIdle);
+
+                borderRef = new WeakReference(border);
+                windowRef = new WeakReference(window);
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                Dispatcher.CurrentDispatcher.InvokeShutdown();
+            }
+        });
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+
+        Assert.IsTrue(thread.Join(TimeSpan.FromSeconds(30)), "the window thread should finish");
+
+        // The thread's own references are gone once it exits; clear ours too so only the WPF static
+        // table can still be holding the objects.
+        GC.KeepAlive(borderRef);
+        if (failure != null) throw failure;
+
+        return (borderRef!, windowRef!);
+    }
+
+    private static bool IsAliveAfterFullCollection(WeakReference reference)
+    {
+        for (var i = 0; i < 4; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+        return reference.IsAlive;
+    }
+}


### PR DESCRIPTION
## 问题

`RoundedClip` 用 `DependencyPropertyDescriptor.AddValueChanged` 监听每个 `Border` 的 `CornerRadius` 变化，但**从未移除**这个处理器。

这个 API 会把目标元素登记进一个**进程级静态表**（`Type._attachedPropertyBrowsableType` → `Dictionary<DependencyObject, PropertyChangeTracker>`），而 `RemoveValueChanged` 是唯一能把它取出来的方式。代码里没有调用，于是**每个关闭的窗口都通过它内部的 Border 留在堆里**。

## 症状

表现为「用一会儿就越来越卡，重启就恢复」。转储实测（一个反复开关内联搜索窗口的进程）：

| 对象 | 数量 | 大小 |
|---|---|---|
| `InlineSearchWindow`（本应只有 1 个） | **17** | 每个拖一整棵可视化树 |
| `WeakEventTable+EventKey[]` | 193 | 21.3 MB |
| `EffectiveValueEntry[]` | 89,180 | 17.6 MB |
| `BindingExpression` | 41,810 | 6.0 MB |
| 托管堆总量 | 372 万对象 | **287.8 MB** |

GC 根路径直接指了出来：

```
System.Type._attachedPropertyBrowsableType (static)
  → Dictionary<DependencyObject, PropertyChangeTracker>
    → Border → EffectiveValueEntry[]
      → InlineSearchWindow     ← 无法回收
```

这些残留对象让之后每一次 UI 线程事件分发都变慢一点。设置窗口受影响最明显——插件页的可视化树最大（29 个插件），遍历代价最高，于是「设置 → 插件」最先感觉出卡。

## 修复

订阅改为按 Border 弱引用保存，并在 **`Unloaded` 时调用 `RemoveValueChanged`** 解除。运行时动态修改 `CornerRadius`（最大化时的窗口 chrome、内联窗口的停靠模式切换）行为完全不变——那正是这个订阅存在的意义。

## 验证

- 新增 `RoundedClipTests`：真实开窗→关闭→强制 GC，断言 Border 与窗口可被回收。
- **配套反证用例**：保留 `AddValueChanged` 不移除时断言对象仍被钉住——确保前一条测试不是因为 GC 时机凑巧而通过，而是真的在测量这个修复。
- 修复后同样的开关循环：`InlineSearchWindow` 存活数 **0**、`WeakEventTable` 条目 **0**、托管堆降到 65 MB（原 287.8 MB）。
- `Tests/App` 全量 1454 通过。

## 影响范围

`RoundedClip` 被所有自绘圆角窗口使用（内联搜索、快速搜索、设置、LocalSend、QuickPanel、若干对话框）。修复是局部的：只多了取消订阅，不改变任何渲染结果。

---

（这个 PR 基于 `main` 上的 `v5.5.4`，可直接干净合并。）
