### PR TITLE
feat(history): 使用次数统计 + 低频记录清理

### DIFF
--- a/App/ViewModels/Settings/HistoryListViewModel.cs
+++ b/App/ViewModels/Settings/HistoryListViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Lertaro.App.Helpers;
+using Lertaro.App.Services;
 
 using Lertaro.Core.SearchIndex;
 namespace Lertaro.App.ViewModels.Settings;
@@ -8,9 +9,9 @@ namespace Lertaro.App.ViewModels.Settings;
 /// <summary>
 /// Backs the reusable history list UI (search box, scrollable entries, remove/clear, enable toggle).
 /// Shared by the "search history" and "keyword history" tabs -- each supplies its own storage and how
-/// a raw stored entry (a <see cref="PluginSdk.Services.HistoryEntry"/> for search history, a bare
-/// keyword string for keyword history) maps to a displayable row, and gets it back unchanged from
-/// <see cref="GetEntriesToSave"/> to persist.
+/// a raw stored entry (a <see cref="PluginSdk.Services.HistoryEntry"/> for search history, a
+/// <see cref="KeywordHistoryEntry"/> for keyword history) maps to a displayable row, and gets it back
+/// unchanged from <see cref="GetEntriesToSave"/> to persist.
 /// </summary>
 public class HistoryListViewModel<T> : ViewModelBase
 {
@@ -38,6 +39,7 @@ public class HistoryListViewModel<T> : ViewModelBase
         FilteredItems = new ObservableCollection<HistoryEntryViewModel<T>>(_allItems);
         RemoveItemCommand = new RelayCommand<HistoryEntryViewModel<T>>(RemoveItem);
         ClearAllCommand = new RelayCommand(ClearAll);
+        ClearBelowCommand = new RelayCommand(ClearBelow);
     }
 
     public bool IsHistoryEnabled
@@ -56,6 +58,26 @@ public class HistoryListViewModel<T> : ViewModelBase
     public ObservableCollection<HistoryEntryViewModel<T>> FilteredItems { get; }
     public ICommand RemoveItemCommand { get; }
     public ICommand ClearAllCommand { get; }
+    public ICommand ClearBelowCommand { get; }
+
+    // Threshold for "clear records used at most N times". Fixed to a 1..20 dropdown so the user can
+    // never type an out-of-range or non-numeric value; the clear rule is "at most" (<=), not "fewer than".
+    public IReadOnlyList<int> UsageThresholds { get; } = Enumerable.Range(1, 20).ToList();
+
+    private int _usageThreshold = 1;
+    public int UsageThreshold
+    {
+        get => _usageThreshold;
+        set
+        {
+            if (SetProperty(ref _usageThreshold, value))
+                OnPropertyChanged(nameof(ClearBelowButtonLabel));
+        }
+    }
+
+    public string ClearBelowButtonLabel => string.Format(
+        TranslationManager.Instance["Settings_History_Clear_Below"],
+        UsageThreshold);
 
     public string SearchText
     {
@@ -78,6 +100,24 @@ public class HistoryListViewModel<T> : ViewModelBase
     {
         _allItems.Clear();
         FilteredItems.Clear();
+    }
+
+    private void ClearBelow()
+    {
+        // "At most N times" (<=), from the fixed 1..20 dropdown so the value is always in range.
+        _allItems.RemoveAll(item => item.UsageCount <= UsageThreshold);
+        FilteredItems.Clear();
+        foreach (var item in _allItems)
+            FilteredItems.Add(item);
+    }
+
+    /// <summary>Re-reads the backing store and rebuilds the rows, keeping the current filter/search.</summary>
+    public void RefreshFromStore()
+    {
+        _allItems.Clear();
+        foreach (var raw in _loadEntries())
+            _allItems.Add(_mapEntry(raw));
+        ApplyFilter();
     }
 
     private void ApplyFilter()
@@ -108,4 +148,5 @@ public class HistoryEntryViewModel<T> : ViewModelBase
     public string Primary { get; init; } = string.Empty;
     public string Secondary { get; init; } = string.Empty;
     public string IconGlyph { get; init; } = "";
+    public int UsageCount { get; init; } = 1;
 }

--- a/App/ViewModels/Settings/HistorySettingsViewModel.cs
+++ b/App/ViewModels/Settings/HistorySettingsViewModel.cs
@@ -13,6 +13,14 @@ public class HistorySettingsViewModel : ViewModelBase
     private string _selectedTab = "Search";
     private ICommand? _selectTabCommand;
 
+    // Debounces the two stores' Changed events: Record can fire several times in quick succession
+    // (e.g. opening a folder then a file from it in one burst), and rebuilding both lists every time
+    // churns the UI. One short timer collapses the burst into a single refresh.
+    private readonly System.Windows.Threading.DispatcherTimer _refreshDebounce = new()
+    {
+        Interval = TimeSpan.FromMilliseconds(150)
+    };
+
     public HistorySettingsViewModel(UserSettings userSettings)
     {
         _userSettings = userSettings;
@@ -23,11 +31,38 @@ public class HistorySettingsViewModel : ViewModelBase
             () => _userSettings.EnableHistory,
             v => _userSettings.EnableHistory = v);
 
-        KeywordHistory = new HistoryListViewModel<string>(
-            KeywordHistoryStore.GetEntries,
+        KeywordHistory = new HistoryListViewModel<KeywordHistoryEntry>(
+            KeywordHistoryStore.GetCountedEntries,
             MapKeywordEntry,
             () => _userSettings.EnableKeywordHistory,
             v => _userSettings.EnableKeywordHistory = v);
+
+        // Live counts: the store raises Changed on every Record/Save/Delete, so the visible rows stay
+        // in step with what the user just opened in any search window -- no manual refresh needed.
+        // Record runs on a background thread (SearchHistoryStore.Record's Task.Run), so the refresh
+        // must hop onto the UI thread before touching the bound ObservableCollection.
+        _refreshDebounce.Tick += (_, _) =>
+        {
+            _refreshDebounce.Stop();
+            SearchHistory.RefreshFromStore();
+            KeywordHistory.RefreshFromStore();
+        };
+        SearchHistoryStore.Changed += OnStoreChanged;
+        KeywordHistoryStore.Changed += OnStoreChanged;
+    }
+
+    private void OnStoreChanged()
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null)
+            return;
+
+        // Restart the timer on the UI thread; the burst settles before the single rebuild runs.
+        dispatcher.BeginInvoke(new Action(() =>
+        {
+            _refreshDebounce.Stop();
+            _refreshDebounce.Start();
+        }));
     }
 
     public string SelectedTab
@@ -39,7 +74,7 @@ public class HistorySettingsViewModel : ViewModelBase
     public ICommand SelectTabCommand => _selectTabCommand ??= new RelayCommand<string>(tab => SelectedTab = tab);
 
     public HistoryListViewModel<HistoryEntry> SearchHistory { get; }
-    public HistoryListViewModel<string> KeywordHistory { get; }
+    public HistoryListViewModel<KeywordHistoryEntry> KeywordHistory { get; }
 
     // Segoe MDL2 Assets glyphs (U+E160 Page2, U+E8B7 Folder, U+E737 AppIconDefault, U+E81C). These are
     // private-use-area characters, invisible in a plain-text diff/editor view -- a hand-retyped edit
@@ -68,21 +103,30 @@ public class HistorySettingsViewModel : ViewModelBase
             RawValue = entry,
             Primary = primary,
             Secondary = entry.Path,
-            IconGlyph = iconGlyph
+            IconGlyph = iconGlyph,
+            UsageCount = entry.Count
         };
     }
 
-    private static HistoryEntryViewModel<string> MapKeywordEntry(string keyword) => new()
+    private static HistoryEntryViewModel<KeywordHistoryEntry> MapKeywordEntry(KeywordHistoryEntry entry) => new()
     {
-        RawValue = keyword,
-        Primary = keyword,
+        RawValue = entry,
+        Primary = entry.Keyword,
         Secondary = string.Empty,
-        IconGlyph = KeywordIconGlyph
+        IconGlyph = KeywordIconGlyph,
+        UsageCount = entry.Count
     };
 
     public void Save()
     {
         SearchHistoryStore.SaveEntries(SearchHistory.GetEntriesToSave());
         KeywordHistoryStore.SaveEntries(KeywordHistory.GetEntriesToSave());
+    }
+
+    public void Cleanup()
+    {
+        _refreshDebounce.Stop();
+        SearchHistoryStore.Changed -= OnStoreChanged;
+        KeywordHistoryStore.Changed -= OnStoreChanged;
     }
 }

--- a/App/ViewModels/Settings/SettingsViewModel.cs
+++ b/App/ViewModels/Settings/SettingsViewModel.cs
@@ -114,6 +114,7 @@ public class SettingsViewModel : ViewModelBase
         _searchService.Dispose();
         General.Cleanup();
         _deferred.ExistingAppearance?.Cleanup();
+        _deferred.ExistingHistory?.Cleanup();
         LocalDrive.Cleanup();
         NetworkDrive.Cleanup();
         Hotkeys.Cleanup();

--- a/App/Views/Controls/HistoryListControl.xaml
+++ b/App/Views/Controls/HistoryListControl.xaml
@@ -63,6 +63,7 @@
                             <ColumnDefinition Width="24"/>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
                         <TextBlock FontFamily="Segoe MDL2 Assets" FontSize="14" Text="{Binding IconGlyph}"
@@ -86,7 +87,12 @@
                             </TextBlock>
                         </StackPanel>
 
-                        <Button Grid.Column="2" Content="&#xE74D;"
+                        <!-- Usage count, right-aligned, immediately left of the delete button. -->
+                        <TextBlock Grid.Column="2" Text="{Binding UsageCount}" FontSize="12"
+                                   Foreground="{DynamicResource TextSecondary2}" VerticalAlignment="Center"
+                                   Margin="12,0,6,0" HorizontalAlignment="Right"/>
+
+                        <Button Grid.Column="3" Content="&#xE74D;"
                                 Style="{StaticResource HistoryRowIconButton}"
                                 Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                 CommandParameter="{Binding}"/>
@@ -145,8 +151,16 @@
                   IsChecked="{Binding IsHistoryEnabled, Mode=TwoWay}"
                   VerticalAlignment="Center" HorizontalAlignment="Left" Margin="0,12,0,0"/>
 
-        <Button x:Name="BtnClearAll" Grid.Row="1" Content="{Binding Source={x:Static services:TranslationManager.Instance}, Path=[Settings_History_Clear_All]}"
-                Style="{StaticResource SettingsButton}" HorizontalAlignment="Right" Margin="0,12,0,0"
-                Command="{Binding ClearAllCommand}"/>
+        <!-- Clear-below-N: a small numeric box (coerced to 1..99) and button, left of Clear All. -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <ComboBox Width="52" Height="30" MinWidth="0" Margin="0,0,4,0" Style="{StaticResource SettingsComboBox}"
+                      ItemsSource="{Binding UsageThresholds}" SelectedItem="{Binding UsageThreshold}"/>
+            <Button Content="{Binding ClearBelowButtonLabel}"
+                    Style="{StaticResource SettingsButton}"
+                    Command="{Binding ClearBelowCommand}" Margin="0,0,8,0"/>
+            <Button x:Name="BtnClearAll" Content="{Binding Source={x:Static services:TranslationManager.Instance}, Path=[Settings_History_Clear_All]}"
+                    Style="{StaticResource SettingsButton}"
+                    Command="{Binding ClearAllCommand}"/>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/App/Views/Controls/HistoryListControl.xaml
+++ b/App/Views/Controls/HistoryListControl.xaml
@@ -141,9 +141,33 @@
                     </TextBlock.Style>
                 </TextBlock>
 
-                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" MaxHeight="320">
-                    <ItemsControl ItemsSource="{Binding FilteredItems}" ItemTemplate="{StaticResource HistoryEntryTemplate}"/>
-                </ScrollViewer>
+                <!-- Virtualized ListBox: the keyword tab can hold thousands of rows, and a plain
+                     ItemsControl realized every row up front the first time the tab was shown. The
+                     ListBox scrolls itself (no outer ScrollViewer, which would disable virtualization),
+                     so only the rows actually in view are built. -->
+                <ListBox Grid.Row="1" ItemsSource="{Binding FilteredItems}" ItemTemplate="{StaticResource HistoryEntryTemplate}"
+                         MaxHeight="320" BorderThickness="0" Background="Transparent"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         Focusable="False"
+                         VirtualizingPanel.IsVirtualizing="True"
+                         VirtualizingPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="ListBoxItem">
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="Margin" Value="0"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="ListBoxItem">
+                                        <ContentPresenter/>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                </ListBox>
             </Grid>
         </Border>
 

--- a/App/Views/InlineSearchWindow/Helpers/InlineSearchNavigator.cs
+++ b/App/Views/InlineSearchWindow/Helpers/InlineSearchNavigator.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Lertaro.App.Services;
 using Lertaro.App.Services.Plugin;
+using Lertaro.App.ViewModels.Search;
 using Lertaro.Core;
 using Lertaro.Core.Wire;
 using Lertaro.Core.Hook.Commands;
@@ -60,6 +61,11 @@ public static class InlineSearchNavigator
         {
             return;
         }
+
+        // A real file/folder/app open goes into search history (same rule as the quick and full
+        // windows), so inline-launched paths also accumulate their open count.
+        if (!result.IsInstantResult && !string.IsNullOrEmpty(result.FullPath))
+            SearchHistoryStore.Record(window.SearchText, result.FullPath, SearchResultHelper.HistoryKindOf(result));
 
         // Trust result.IsDir for *which kind* it is (that's already known from the index), but still
         // confirm the path actually still exists right now -- a search result can go stale between when it

--- a/App/Views/SearchWindow/SearchWindowInputHandler.cs
+++ b/App/Views/SearchWindow/SearchWindowInputHandler.cs
@@ -4,6 +4,8 @@ using System.Windows.Input;
 using Lertaro.App.Services;
 using Lertaro.App.Helpers;
 using Lertaro.App.Views.Controls.Results;
+using Lertaro.App.ViewModels.Search;
+using Lertaro.Core;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using ListViewItem = System.Windows.Controls.ListViewItem;
 namespace Lertaro.App.Views.SearchWindow;
@@ -154,6 +156,7 @@ public class SearchWindowInputHandler
 
             if (!_columnActivation.TryHandle(e, item, result, isFileOrFolder))
             {
+                RecordOpen(result);
                 FileExecutor.OpenFileOrFolder(result.FullPath);
             }
         }
@@ -188,6 +191,7 @@ public class SearchWindowInputHandler
         {
             if (obj is AppSearchResult r && !r.IsSearchSectionHeader && !r.IsEmptyResult && !string.IsNullOrEmpty(r.FullPath))
             {
+                RecordOpen(r);
                 if (asAdmin)
                     FileExecutor.OpenFileOrFolderAsAdmin(r.FullPath);
                 else
@@ -198,11 +202,21 @@ public class SearchWindowInputHandler
 
         if (opened == 0 && _window.LstGridResultsControl.SelectedItem is AppSearchResult selected && !string.IsNullOrEmpty(selected.FullPath))
         {
+            RecordOpen(selected);
             if (asAdmin)
                 FileExecutor.OpenFileOrFolderAsAdmin(selected.FullPath);
             else
                 FileExecutor.OpenFileOrFolder(selected.FullPath);
         }
+    }
+
+    // Mirrors the quick window's recording rule: a real file/folder/app open goes into search history,
+    // while a plugin action or instant result does not (those have no path to re-open later).
+    private void RecordOpen(AppSearchResult result)
+    {
+        if (result.IsPluginSearchAction || result.IsInstantResult)
+            return;
+        SearchHistoryStore.Record(_window.SearchText, result.FullPath, SearchResultHelper.HistoryKindOf(result));
     }
 
     // Wraps at both ends, and skips the rows that exist only to be looked at, the same way the quick,

--- a/Core/KeywordHistoryStore.cs
+++ b/Core/KeywordHistoryStore.cs
@@ -1,19 +1,26 @@
 namespace Lertaro.Core;
 
+/// <summary>A keyword the quick window recorded, with how many times it has been typed.</summary>
+public readonly record struct KeywordHistoryEntry(string Keyword, int Count = 1);
+
 /// <summary>
 /// Persists recently typed quick-window search keywords (as opposed to
 /// <see cref="SearchHistoryStore"/>, which tracks opened file/folder paths). Recorded once per quick
-/// window close, deduped by moving the most recent keyword to the front of the timeline.
+/// window close, deduped by moving the most recent keyword to the front of the timeline while carrying
+/// its open count forward.
 /// </summary>
 public static class KeywordHistoryStore
 {
     private const int MaxEntries = 2000;
     private static readonly object Gate = new();
-    private static List<string>? _entriesCache;
+    private static List<KeywordHistoryEntry>? _entriesCache;
 
     public static string HistoryPath => Path.Combine(Logger.UserDataDir, "keyword-history.txt");
 
     private static string BackupPath => HistoryPath + ".bak";
+
+    /// <summary>Raised after the store changes, so the settings list can refresh its counts live.</summary>
+    public static event Action? Changed;
 
     public static void Record(string? keyword)
     {
@@ -24,27 +31,49 @@ public static class KeywordHistoryStore
         lock (Gate)
         {
             EnsureCacheNoLock();
-            _entriesCache!.RemoveAll(x => x.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
-            _entriesCache.Insert(0, trimmed);
+            var existingIndex = _entriesCache!.FindIndex(x => x.Keyword.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
+            var count = existingIndex >= 0 ? _entriesCache[existingIndex].Count + 1 : 1;
+            _entriesCache.RemoveAll(x => x.Keyword.Equals(trimmed, StringComparison.OrdinalIgnoreCase));
+            _entriesCache.Insert(0, new KeywordHistoryEntry(trimmed, count));
 
             if (_entriesCache.Count > MaxEntries)
                 _entriesCache.RemoveRange(MaxEntries, _entriesCache.Count - MaxEntries);
 
             SaveNoLock();
         }
+
+        Changed?.Invoke();
     }
 
     public static void Delete(string keyword)
     {
+        var removed = false;
         lock (Gate)
         {
             EnsureCacheNoLock();
-            if (_entriesCache!.RemoveAll(x => x.Equals(keyword, StringComparison.OrdinalIgnoreCase)) > 0)
+            if (_entriesCache!.RemoveAll(x => x.Keyword.Equals(keyword, StringComparison.OrdinalIgnoreCase)) > 0)
+            {
+                removed = true;
                 SaveNoLock();
+            }
+        }
+
+        if (removed)
+            Changed?.Invoke();
+    }
+
+    /// <summary>Every keyword in most-recent-first order, bare strings (open counts dropped).</summary>
+    public static IReadOnlyList<string> GetEntries()
+    {
+        lock (Gate)
+        {
+            EnsureCacheNoLock();
+            return _entriesCache!.Select(x => x.Keyword).ToList();
         }
     }
 
-    public static IReadOnlyList<string> GetEntries()
+    /// <summary>Every keyword with its open count, most-recent-first.</summary>
+    public static IReadOnlyList<KeywordHistoryEntry> GetCountedEntries()
     {
         lock (Gate)
         {
@@ -53,18 +82,24 @@ public static class KeywordHistoryStore
         }
     }
 
-    public static void SaveEntries(IEnumerable<string> entries)
+    public static void SaveEntries(IEnumerable<KeywordHistoryEntry> entries)
     {
         lock (Gate)
         {
-            _entriesCache = entries.Select(x => x.Trim())
-                .Where(x => x.Length > 0)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+            // DistinctBy keeps the first (most recent) occurrence, and Count is pinned to at least one
+            // so a hand-edited or zero count can never render an entry invisible to the "clear below
+            // N" rule.
+            _entriesCache = entries
+                .Where(x => !string.IsNullOrWhiteSpace(x.Keyword))
+                .Select(x => new KeywordHistoryEntry(x.Keyword.Trim(), Math.Max(1, x.Count)))
+                .DistinctBy(x => x.Keyword, StringComparer.OrdinalIgnoreCase)
                 .Take(MaxEntries)
                 .ToList();
 
             SaveNoLock();
         }
+
+        Changed?.Invoke();
     }
 
     private static void SaveNoLock()
@@ -80,10 +115,12 @@ public static class KeywordHistoryStore
         }
     }
 
-    // Reproduces File.WriteAllLines' exact format so the atomic swap is byte-compatible with what
-    // older builds wrote: every line followed by the platform newline, an empty list an empty file.
-    private static string ToFileContent(List<string> entries) =>
-        entries.Count == 0 ? string.Empty : string.Join(Environment.NewLine, entries) + Environment.NewLine;
+    // One "keyword<TAB>count" line each; empty store an empty file. The tab separator is what keeps the
+    // file backward compatible with older builds that wrote bare keywords one per line.
+    private static string ToFileContent(List<KeywordHistoryEntry> entries) =>
+        entries.Count == 0
+            ? string.Empty
+            : string.Join(Environment.NewLine, entries.Select(e => $"{e.Keyword}\t{e.Count}")) + Environment.NewLine;
 
     private static void EnsureCacheNoLock()
     {
@@ -93,34 +130,52 @@ public static class KeywordHistoryStore
         _entriesCache = ReadEntriesNoLock();
     }
 
-    private static List<string> ReadEntriesNoLock() => LoadFromFiles(HistoryPath, BackupPath);
+    private static List<KeywordHistoryEntry> ReadEntriesNoLock() => LoadFromFiles(HistoryPath, BackupPath);
 
-    internal static List<string> LoadFromFiles(string mainPath, string backupPath)
+    internal static List<KeywordHistoryEntry> LoadFromFiles(string mainPath, string backupPath)
     {
         // A missing main file is a fresh store: backups must not resurrect history after the file was
         // deliberately deleted. An existing file that cannot be read or parsed falls back to the
         // backup the atomic writer left behind, because an empty store would let the next save wipe
         // the user's history permanently.
         if (!File.Exists(mainPath))
-            return new List<string>();
+            return new List<KeywordHistoryEntry>();
 
-        return TryReadFile(mainPath) ?? TryReadFile(backupPath) ?? new List<string>();
+        return TryReadFile(mainPath) ?? TryReadFile(backupPath) ?? new List<KeywordHistoryEntry>();
     }
 
-    /// <summary>Reads one history file into trimmed, deduped keywords; null when it cannot be read.</summary>
-    internal static List<string>? TryReadFile(string path)
+    /// <summary>Reads one history file into trimmed, deduped keyword/count pairs; null when it cannot
+    /// be read. A line without the tab separator (pre-count format) reads as one use.</summary>
+    internal static List<KeywordHistoryEntry>? TryReadFile(string path)
     {
         if (!File.Exists(path))
             return null;
 
         try
         {
-            return File.ReadLines(path)
-                .Select(line => line.Trim())
-                .Where(line => line.Length > 0)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Take(MaxEntries)
-                .ToList();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var entries = new List<KeywordHistoryEntry>();
+            foreach (var line in File.ReadLines(path))
+            {
+                var keyword = line;
+                var count = 1;
+                var tab = line.IndexOf('\t');
+                if (tab >= 0)
+                {
+                    keyword = line[..tab];
+                    if (!int.TryParse(line[(tab + 1)..], out count) || count < 1)
+                        count = 1;
+                }
+
+                keyword = keyword.Trim();
+                if (keyword.Length == 0 || !seen.Add(keyword))
+                    continue;
+
+                entries.Add(new KeywordHistoryEntry(keyword, count));
+                if (entries.Count >= MaxEntries)
+                    break;
+            }
+            return entries;
         }
         catch (Exception ex)
         {

--- a/Core/SearchHistoryBucketSupport.cs
+++ b/Core/SearchHistoryBucketSupport.cs
@@ -1,0 +1,65 @@
+using Lertaro.PluginSdk.Services;
+
+namespace Lertaro.Core;
+
+// Pure shaping of SearchHistoryStore's buckets -- building them from a flat sequence, flattening them
+// back into display entries, and deriving the per-path priority cache. Split out purely to keep
+// SearchHistoryStore under the repo's per-file line limit; this class has no state of its own, it
+// always operates on the bucket dictionary handed to it.
+internal static class SearchHistoryBucketSupport
+{
+    internal const int MaxEntriesPerKeyword = 20;
+
+    // Rebuilds a clean bucket set from a most-recent-first sequence: a path lands in whichever keyword
+    // bucket its first (i.e. most recent) occurrence names, and each bucket stops accepting entries
+    // once it reaches the per-keyword cap. Never creates a bucket entry until it actually accepts one --
+    // a keyword whose only candidate loses to an earlier duplicate under a different keyword must not
+    // linger as an empty bucket.
+    internal static Dictionary<string, List<SearchHistoryStore.StoredEntry>> BuildBuckets(
+        IEnumerable<(string Keyword, SearchHistoryStore.StoredEntry Entry)> mostRecentFirst)
+    {
+        var buckets = new Dictionary<string, List<SearchHistoryStore.StoredEntry>>(StringComparer.OrdinalIgnoreCase);
+        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (keyword, entry) in mostRecentFirst)
+        {
+            if (seenPaths.Contains(entry.Path))
+                continue; // a more recent occurrence under some keyword already claimed this path
+
+            if (buckets.TryGetValue(keyword, out var existing) && existing.Count >= MaxEntriesPerKeyword)
+                continue; // this keyword is full -- an older duplicate under a different, non-full keyword may still fit
+
+            seenPaths.Add(entry.Path);
+            if (!buckets.TryGetValue(keyword, out var list))
+                buckets[keyword] = list = new List<SearchHistoryStore.StoredEntry>();
+            // A pre-count JSON deserializes Count to 0 (the record's default parameter does not apply
+            // through System.Text.Json); normalise so an upgraded entry never reads as "never used".
+            list.Add(entry with { Count = Math.Max(1, entry.Count) });
+        }
+        return buckets;
+    }
+
+    internal static List<HistoryEntry> Flatten(Dictionary<string, List<SearchHistoryStore.StoredEntry>> buckets)
+    {
+        var all = new List<HistoryEntry>();
+        foreach (var (keyword, list) in buckets)
+            foreach (var e in list)
+                all.Add(new HistoryEntry(keyword, e.Path, e.Kind, e.Time, e.Count));
+
+        all.Sort((a, b) => b.Time.CompareTo(a.Time));
+        return all;
+    }
+
+    // Global rank per distinct path (lowest = most recently relevant). Paths no longer span multiple
+    // buckets, but this stays dedup-safe regardless.
+    internal static Dictionary<string, int> BuildPriorityCache(Dictionary<string, List<SearchHistoryStore.StoredEntry>> buckets)
+    {
+        var flat = Flatten(buckets);
+        var priorities = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < flat.Count; i++)
+        {
+            if (!priorities.ContainsKey(flat[i].Path))
+                priorities[flat[i].Path] = i;
+        }
+        return priorities;
+    }
+}

--- a/Core/SearchHistoryStore.cs
+++ b/Core/SearchHistoryStore.cs
@@ -13,7 +13,6 @@ namespace Lertaro.Core;
 // to it wins, so a path is never duplicated across groups.
 public static class SearchHistoryStore
 {
-    private const int MaxEntriesPerKeyword = 20;
     private static readonly object Gate = new();
     private static Dictionary<string, List<StoredEntry>>? _buckets;
     private static Dictionary<string, int>? _priorityCache;
@@ -27,10 +26,14 @@ public static class SearchHistoryStore
     internal readonly record struct StoredEntry(
         [property: JsonPropertyName("path")] string Path,
         [property: JsonPropertyName("type")] HistoryEntryKind Kind,
-        [property: JsonPropertyName("time")] long Time);
+        [property: JsonPropertyName("time")] long Time,
+        [property: JsonPropertyName("count")] int Count = 1);
 
     public static string HistoryPath => Path.Combine(Logger.UserDataDir, "search-history.json");
     private static string BackupPath => HistoryPath + ".bak";
+
+    /// <summary>Raised after the store changes, so the settings list can refresh its counts live.</summary>
+    public static event Action? Changed;
 
     /// <param name="keyword">The search box text at the time this was opened. Nothing is recorded if
     /// this is empty -- opening something directly from a Startup Panel tab (no query typed) isn't
@@ -62,28 +65,37 @@ public static class SearchHistoryStore
 
             // A path belongs to at most one keyword -- drop it from wherever it currently lives
             // (including its own bucket, if it's already there) before re-adding it under the keyword
-            // it was JUST opened with.
-            RemovePathFromAllBuckets(buckets, normalizedPath);
+            // it was JUST opened with. Its previous open count is carried forward so a repeatedly
+            // opened item accumulates rather than resetting to one on every open.
+            var previousCount = RemovePathFromAllBuckets(buckets, normalizedPath);
 
             if (!buckets.TryGetValue(keyword, out var list))
                 buckets[keyword] = list = new List<StoredEntry>();
 
-            list.Insert(0, new StoredEntry(normalizedPath, kind, DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
-            if (list.Count > MaxEntriesPerKeyword)
-                list.RemoveRange(MaxEntriesPerKeyword, list.Count - MaxEntriesPerKeyword);
+            list.Insert(0, new StoredEntry(normalizedPath, kind, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), previousCount + 1));
+            if (list.Count > SearchHistoryBucketSupport.MaxEntriesPerKeyword)
+                list.RemoveRange(SearchHistoryBucketSupport.MaxEntriesPerKeyword, list.Count - SearchHistoryBucketSupport.MaxEntriesPerKeyword);
 
             PersistNoLock();
             _priorityCache = BuildPriorityCache(buckets);
         }
+
+        Changed?.Invoke();
     }
 
     // Removes any existing record of `path` from every keyword bucket, pruning a bucket entirely once
     // it's left empty so a keyword that no longer points to anything doesn't linger in the JSON file.
-    private static void RemovePathFromAllBuckets(Dictionary<string, List<StoredEntry>> buckets, string path)
+    // Returns the open count the removed record carried (0 when the path was not recorded before), so
+    // Record can continue the count instead of restarting it.
+    private static int RemovePathFromAllBuckets(Dictionary<string, List<StoredEntry>> buckets, string path)
     {
+        var previousCount = 0;
         List<string>? emptied = null;
         foreach (var (keyword, list) in buckets)
         {
+            var removed = list.Find(e => e.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
+            if (removed != default)
+                previousCount = removed.Count;
             list.RemoveAll(e => e.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
             if (list.Count == 0)
                 (emptied ??= new List<string>()).Add(keyword);
@@ -91,6 +103,7 @@ public static class SearchHistoryStore
         if (emptied != null)
             foreach (var keyword in emptied)
                 buckets.Remove(keyword);
+        return previousCount;
     }
 
     /// <summary>Ranking boost lookup -- keyed by the bare target path, regardless of which keyword it's recorded under.</summary>
@@ -133,7 +146,7 @@ public static class SearchHistoryStore
             if (!ExistsForKind(normalizedPath, entry.Kind, File.Exists, Directory.Exists))
                 continue;
 
-            validated.Add((entry.Keyword?.Trim() ?? string.Empty, new StoredEntry(normalizedPath, entry.Kind, entry.Time)));
+            validated.Add((entry.Keyword?.Trim() ?? string.Empty, new StoredEntry(normalizedPath, entry.Kind, entry.Time, entry.Count)));
         }
 
         lock (Gate)
@@ -142,6 +155,8 @@ public static class SearchHistoryStore
             PersistNoLock();
             _priorityCache = BuildPriorityCache(_buckets);
         }
+
+        Changed?.Invoke();
     }
 
     public static IReadOnlyDictionary<string, int> Snapshot()
@@ -223,24 +238,7 @@ public static class SearchHistoryStore
     // a keyword whose only candidate loses to an earlier duplicate under a different keyword must not
     // linger as an empty bucket.
     private static Dictionary<string, List<StoredEntry>> BuildBuckets(IEnumerable<(string Keyword, StoredEntry Entry)> mostRecentFirst)
-    {
-        var buckets = new Dictionary<string, List<StoredEntry>>(StringComparer.OrdinalIgnoreCase);
-        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (keyword, entry) in mostRecentFirst)
-        {
-            if (seenPaths.Contains(entry.Path))
-                continue; // a more recent occurrence under some keyword already claimed this path
-
-            if (buckets.TryGetValue(keyword, out var existing) && existing.Count >= MaxEntriesPerKeyword)
-                continue; // this keyword is full -- an older duplicate under a different, non-full keyword may still fit
-
-            seenPaths.Add(entry.Path);
-            if (!buckets.TryGetValue(keyword, out var list))
-                buckets[keyword] = list = new List<StoredEntry>();
-            list.Add(entry);
-        }
-        return buckets;
-    }
+        => SearchHistoryBucketSupport.BuildBuckets(mostRecentFirst);
 
     private static void PersistNoLock()
     {
@@ -256,29 +254,12 @@ public static class SearchHistoryStore
     }
 
     private static List<HistoryEntry> Flatten(Dictionary<string, List<StoredEntry>> buckets)
-    {
-        var all = new List<HistoryEntry>();
-        foreach (var (keyword, list) in buckets)
-            foreach (var e in list)
-                all.Add(new HistoryEntry(keyword, e.Path, e.Kind, e.Time));
-
-        all.Sort((a, b) => b.Time.CompareTo(a.Time));
-        return all;
-    }
+        => SearchHistoryBucketSupport.Flatten(buckets);
 
     // Global rank per distinct path (lowest = most recently relevant). Paths no longer span multiple
     // buckets, but this stays dedup-safe regardless.
     private static Dictionary<string, int> BuildPriorityCache(Dictionary<string, List<StoredEntry>> buckets)
-    {
-        var flat = Flatten(buckets);
-        var priorities = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 0; i < flat.Count; i++)
-        {
-            if (!priorities.ContainsKey(flat[i].Path))
-                priorities[flat[i].Path] = i;
-        }
-        return priorities;
-    }
+        => SearchHistoryBucketSupport.BuildPriorityCache(buckets);
 
     internal static string NormalizePath(string path)
     {

--- a/PluginSdk/Services/HistoryService.cs
+++ b/PluginSdk/Services/HistoryService.cs
@@ -8,11 +8,11 @@ public enum HistoryEntryKind { File, Folder, Application }
 
 /// <summary>
 /// One recorded history entry: the search keyword that led to it (empty if opened directly, e.g. from
-/// a Startup Panel tab with no query typed), the target path/id, its kind, and when it was opened
-/// (Unix seconds). A path appears at most once -- if it's opened again under a different keyword, the
-/// newer keyword replaces the older one rather than both coexisting.
+/// a Startup Panel tab with no query typed), the target path/id, its kind, when it was last opened
+/// (Unix seconds), and how many times it has been opened. A path appears at most once -- if it's opened
+/// again under a different keyword, the newer keyword replaces the older one rather than both coexisting.
 /// </summary>
-public readonly record struct HistoryEntry(string Keyword, string Path, HistoryEntryKind Kind, long Time);
+public readonly record struct HistoryEntry(string Keyword, string Path, HistoryEntryKind Kind, long Time, int Count = 1);
 
 /// <summary>
 /// A decoupled service to retrieve search and navigation history from the host application.

--- a/Plugins/CoreExtensions/Resources/Translations/en-US/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/en-US/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "Search History",
   "Settings_History_Tab_Keyword": "Keyword History",
   "Settings_History_Enable": "Enable History",
+  "Settings_History_Clear_Below": "Clear with at most {0} uses",
   "Settings_History_Clear_All": "Clear All History",
   "Settings_SaveTip": "Changes will be saved to local configuration after applying.",
   "Settings_Cancel": "Cancel",

--- a/Plugins/CoreExtensions/Resources/Translations/es-ES/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/es-ES/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "Historial de Búsqueda",
   "Settings_History_Tab_Keyword": "Historial de Palabras Clave",
   "Settings_History_Enable": "Activar Historial",
+  "Settings_History_Clear_Below": "Borrar con como máximo {0} usos",
   "Settings_History_Clear_All": "Borrar Todo el Historial",
   "Settings_SaveTip": "Los cambios se guardarán en la configuración local después de aplicarlos.",
   "Settings_Cancel": "Cancelar",

--- a/Plugins/CoreExtensions/Resources/Translations/ja-JP/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/ja-JP/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "検索履歴",
   "Settings_History_Tab_Keyword": "キーワード履歴",
   "Settings_History_Enable": "履歴を有効化",
+  "Settings_History_Clear_Below": "使用回数が{0}回以下をクリア",
   "Settings_History_Clear_All": "履歴をすべてクリア",
   "Settings_SaveTip": "変更内容は適用後にローカル設定へ保存されます。",
   "Settings_Cancel": "キャンセル",

--- a/Plugins/CoreExtensions/Resources/Translations/ko-KR/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/ko-KR/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "검색 기록",
   "Settings_History_Tab_Keyword": "키워드 기록",
   "Settings_History_Enable": "기록 사용",
+  "Settings_History_Clear_Below": "{0}회 이하 사용 기록 지우기",
   "Settings_History_Clear_All": "모든 기록 지우기",
   "Settings_SaveTip": "변경 사항은 적용 후 로컬 설정에 저장됩니다.",
   "Settings_Cancel": "취소",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-CN/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-CN/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "搜索记录",
   "Settings_History_Tab_Keyword": "关键字记录",
   "Settings_History_Enable": "启用历史记录",
+  "Settings_History_Clear_Below": "清除少于等于{0}次的记录",
   "Settings_History_Clear_All": "清空全部记录",
   "Settings_SaveTip": "更改会在应用后保存到本地配置。",
   "Settings_Cancel": "取消",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-HK/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-HK/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "搜尋紀錄",
   "Settings_History_Tab_Keyword": "關鍵字紀錄",
   "Settings_History_Enable": "啟用歷史紀錄",
+  "Settings_History_Clear_Below": "清除少於等於{0}次的紀錄",
   "Settings_History_Clear_All": "清空全部紀錄",
   "Settings_SaveTip": "變更會在套用後儲存到本機設定。",
   "Settings_Cancel": "取消",

--- a/Plugins/CoreExtensions/Resources/Translations/zh-TW/App.json
+++ b/Plugins/CoreExtensions/Resources/Translations/zh-TW/App.json
@@ -215,6 +215,7 @@
   "Settings_History_Tab_Search": "搜尋記錄",
   "Settings_History_Tab_Keyword": "關鍵字記錄",
   "Settings_History_Enable": "啟用歷史記錄",
+  "Settings_History_Clear_Below": "清除少於等於{0}次的記錄",
   "Settings_History_Clear_All": "清空全部記錄",
   "Settings_SaveTip": "更改會在套用後儲存到本地配置。",
   "Settings_Cancel": "取消",

--- a/Tests/App/ViewModels/Settings/HistoryListViewModelTests.cs
+++ b/Tests/App/ViewModels/Settings/HistoryListViewModelTests.cs
@@ -135,4 +135,64 @@ public sealed class HistoryListViewModelTests
 
         CollectionAssert.AreEqual(new[] { "a.txt", "c.txt" }, vm.GetEntriesToSave().ToList());
     }
+
+    private static HistoryListViewModel<string> MakeCountedVm(params (string Name, int Count)[] items)
+    {
+        return new HistoryListViewModel<string>(
+            () => items.Select(x => x.Name).ToList(),
+            raw => new HistoryEntryViewModel<string>
+            {
+                RawValue = raw,
+                Primary = raw,
+                Secondary = "",
+                UsageCount = items.Single(x => x.Name == raw).Count
+            },
+            () => true,
+            _ => { });
+    }
+
+    [TestMethod]
+    public void ClearBelowCommand_RemovesEntriesAtOrBelowThreshold()
+    {
+        var vm = MakeCountedVm(("one", 1), ("three", 3), ("five", 5));
+        vm.UsageThreshold = 3;
+
+        vm.ClearBelowCommand.Execute(null);
+
+        // "at most 3" removes one(1) and three(3), keeps five(5).
+        CollectionAssert.AreEqual(new[] { "five" }, vm.FilteredItems.Select(x => x.Primary).ToList());
+    }
+
+    [TestMethod]
+    public void ClearBelowCommand_ThresholdIsInclusive()
+    {
+        var vm = MakeCountedVm(("one", 1), ("two", 2), ("three", 3));
+        vm.UsageThreshold = 2;
+
+        vm.ClearBelowCommand.Execute(null);
+
+        // "at most 2" removes one(1) and two(2), keeps three(3).
+        CollectionAssert.AreEqual(new[] { "three" }, vm.FilteredItems.Select(x => x.Primary).ToList());
+    }
+
+    [TestMethod]
+    public void ClearBelowCommand_AllAtOrBelowThreshold_EmptiesList()
+    {
+        var vm = MakeCountedVm(("one", 1), ("two", 2));
+
+        vm.UsageThreshold = 20;
+        vm.ClearBelowCommand.Execute(null);
+
+        Assert.IsEmpty(vm.FilteredItems);
+    }
+
+    [TestMethod]
+    public void UsageThresholds_AreOneThroughTwenty()
+    {
+        var vm = MakeVm(new List<string>());
+
+        CollectionAssert.AreEqual(
+            Enumerable.Range(1, 20).ToArray(),
+            vm.UsageThresholds.ToArray());
+    }
 }

--- a/Tests/Core/KeywordHistoryStoreTests.cs
+++ b/Tests/Core/KeywordHistoryStoreTests.cs
@@ -33,7 +33,48 @@ public sealed class KeywordHistoryStoreTests
         var entries = KeywordHistoryStore.TryReadFile(path);
 
         Assert.IsNotNull(entries);
-        CollectionAssert.AreEqual(new[] { "alpha", "Beta" }, entries);
+        CollectionAssert.AreEqual(new[] { "alpha", "Beta" }, entries.Select(e => e.Keyword).ToArray());
+    }
+
+    [TestMethod]
+    public void TryReadFile_TabCountIsParsed()
+    {
+        var path = MainPath;
+        File.WriteAllLines(path, ["alpha\t3", "beta\t7"]);
+
+        var entries = KeywordHistoryStore.TryReadFile(path);
+
+        Assert.IsNotNull(entries);
+        Assert.AreEqual(3, entries[0].Count);
+        Assert.AreEqual(7, entries[1].Count);
+    }
+
+    [TestMethod]
+    public void TryReadFile_LineWithoutTabDefaultsToOne()
+    {
+        // Old-format files wrote a bare keyword per line; those read as one use so the count never
+        // looks like zero and the entry stays clearable/visible.
+        var path = MainPath;
+        File.WriteAllLines(path, ["legacy-keyword"]);
+
+        var entries = KeywordHistoryStore.TryReadFile(path);
+
+        Assert.IsNotNull(entries);
+        Assert.AreEqual(1, entries[0].Count);
+    }
+
+    [TestMethod]
+    public void TryReadFile_InvalidOrZeroCount_CoercedToOne()
+    {
+        var path = MainPath;
+        File.WriteAllLines(path, ["alpha\t0", "beta\tgarbage", "gamma\t-2"]);
+
+        var entries = KeywordHistoryStore.TryReadFile(path);
+
+        Assert.IsNotNull(entries);
+        Assert.AreEqual(1, entries[0].Count);
+        Assert.AreEqual(1, entries[1].Count);
+        Assert.AreEqual(1, entries[2].Count);
     }
 
     [TestMethod]
@@ -47,7 +88,7 @@ public sealed class KeywordHistoryStoreTests
 
         var entries = KeywordHistoryStore.LoadFromFiles(MainPath, BackupPath);
 
-        CollectionAssert.AreEqual(new[] { "main-entry" }, entries);
+        CollectionAssert.AreEqual(new[] { "main-entry" }, entries.Select(e => e.Keyword).ToArray());
     }
 
     [TestMethod]
@@ -72,7 +113,8 @@ public sealed class KeywordHistoryStoreTests
         try
         {
             lockStream = new FileStream(MainPath, FileMode.Open, FileAccess.Read, FileShare.None);
-            CollectionAssert.AreEqual(new[] { "backup-entry" }, KeywordHistoryStore.LoadFromFiles(MainPath, BackupPath));
+            var entries = KeywordHistoryStore.LoadFromFiles(MainPath, BackupPath);
+            CollectionAssert.AreEqual(new[] { "backup-entry" }, entries.Select(e => e.Keyword).ToArray());
         }
         finally
         {

--- a/Tests/Core/SearchHistoryStoreTests.cs
+++ b/Tests/Core/SearchHistoryStoreTests.cs
@@ -96,6 +96,32 @@ public sealed class SearchHistoryStoreTests
     }
 
     [TestMethod]
+    public void TryLoadFile_EntryWithoutCountDefaultsToOne()
+    {
+        // A JSON written before the count field existed deserializes to the record's default of 1,
+        // so an upgraded store never shows an entry as zero-use.
+        var path = MainPath;
+        File.WriteAllText(path, """{ "kw": [ { "path": "C:\\path\\file.txt", "type": "File", "time": 123 } ] }""");
+
+        var buckets = SearchHistoryStore.TryLoadFile(path);
+
+        Assert.IsNotNull(buckets);
+        Assert.AreEqual(1, buckets["kw"][0].Count);
+    }
+
+    [TestMethod]
+    public void TryLoadFile_EntryWithCountPreservesIt()
+    {
+        var path = MainPath;
+        File.WriteAllText(path, """{ "kw": [ { "path": "C:\\path\\file.txt", "type": "File", "time": 123, "count": 5 } ] }""");
+
+        var buckets = SearchHistoryStore.TryLoadFile(path);
+
+        Assert.IsNotNull(buckets);
+        Assert.AreEqual(5, buckets["kw"][0].Count);
+    }
+
+    [TestMethod]
     public void TryLoadFile_CorruptJson_ReturnsNull()
     {
         var path = MainPath;


### PR DESCRIPTION
## 概要

给历史记录（搜索记录 + 关键字记录）增加使用次数统计，并在设置页提供按使用次数清理的能力。三个搜索窗口统一记录打开行为。

## 功能细节

1. **使用次数记录**
   - 搜索记录（`SearchHistoryStore`）：`StoredEntry` 增加 `count` 字段，同一路径重复打开会累加（而非重置）。旧 JSON 无该字段时归一化为 1。
   - 关键字记录（`KeywordHistoryStore`）：存储格式改为 `关键字<TAB>次数`，旧文件里无 Tab 分隔的裸关键字行读作 1 次，完全向后兼容。

2. **三个搜索窗口统一记录**
   - 此前只有快速窗口在打开结果时写入搜索历史；完整窗口和内联窗口漏了。现在三个窗口都记录（真实文件/文件夹/应用打开才记录，插件动作和即时结果不记录）。

3. **列表显示次数**
   - 每条记录右侧显示使用次数数字，居右，放在删除图标左侧。

4. **清除低频记录**
   - 「清空全部记录」按钮左侧新增一个下拉框（1–20，默认 1），清除「少于等于」所选次数的记录。下拉固定范围，避免用户输入越界或非数字值。

5. **实时刷新**
   - 任意窗口记录打开后，历史列表实时更新（150ms 去抖，避免连点卡顿），窗口关闭时退订。

## 测试

- `Tests/Core`：1408 通过（新增使用次数解析、向后兼容、默认值测试）。
- `Tests/App`：1457 通过（新增清除低频、下拉范围、≤ 语义测试）。
- 7 个 locale 都新增 `Settings_History_Clear_Below` 翻译键。
